### PR TITLE
Add unit test suite (pytest)

### DIFF
--- a/chessdotcom_ai_coach/views.py
+++ b/chessdotcom_ai_coach/views.py
@@ -71,7 +71,10 @@ def game_detail(request, id):
 @login_required
 async def coach_suggestion(request, id):
     """HTMX endpoint: returns the AI coach's analysis fragment for a game."""
-    game_data = _client_for(request.user).game_detail(id)
+    # Async view: resolve the user via auser() to avoid a synchronous DB
+    # access (request.user is lazy and would raise SynchronousOnlyOperation).
+    user = await request.auser()
+    game_data = _client_for(user).game_detail(id)
     if not game_data:
         return render(
             request,

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,66 @@
+"""
+Global pytest configuration.
+
+Keeps the test suite self-contained: it must run without a live PostgreSQL,
+Ollama or LC0 engine. We (1) provide safe defaults for the environment
+variables that modules read at import time, and (2) swap the database for a
+file-backed SQLite so no PostgreSQL server is needed.
+"""
+
+import os
+import tempfile
+
+# Defaults for env vars read at import time. In particular
+# chessdotcom_ai_coach/services/coach.py does int(os.getenv("CHESS_ENGINE_PORT"))
+# at module level, so a missing value would blow up on import.
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("CHESS_ENGINE_HOST", "127.0.0.1")
+os.environ.setdefault("CHESS_ENGINE_PORT", "9999")
+os.environ.setdefault("OLLAMA_HOST", "http://localhost:11434")
+os.environ.setdefault("OLLAMA_MODEL", "llama3:8b")
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def django_db_modify_db_settings():
+    """Swap the DB for a file-backed SQLite before pytest-django builds it.
+
+    Overriding this hook (rather than ``django_db_setup``) mutates the DB
+    config *before* the default setup runs, so migrations still create the
+    tables — just in SQLite instead of the PostgreSQL configured in
+    settings.py. DB-backed tests then run anywhere with no external services.
+
+    A temp file (not ``:memory:``) is used because the async views are driven
+    through the ASGI test client on worker threads; a shared file DB with a
+    busy timeout is reachable from every connection, whereas each connection
+    to ``:memory:`` would see its own empty database.
+    """
+    from django.conf import settings
+    from django.db import connections
+
+    db_path = os.path.join(tempfile.gettempdir(), "chessdotcom_ai_coach_test.sqlite3")
+    settings.DATABASES["default"] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": db_path,
+        "ATOMIC_REQUESTS": False,
+        "AUTOCOMMIT": True,
+        "CONN_MAX_AGE": 0,
+        "CONN_HEALTH_CHECKS": False,
+        "OPTIONS": {"timeout": 30},
+        "TIME_ZONE": None,
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+        "TEST": {
+            "CHARSET": None,
+            "COLLATION": None,
+            "MIGRATE": True,
+            "MIRROR": None,
+            "NAME": db_path,
+        },
+    }
+    # Rebuild the connection handler so its cached settings point at the new
+    # (SQLite) config instead of the PostgreSQL one loaded from settings.py.
+    connections.__init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,16 @@ dependencies = [
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
+    "pytest-django>=4.12.0",
+]
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "chessdotcom_ai_coach.settings"
+python_files = "test_*.py"
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/tests/test_chess_client.py
+++ b/tests/test_chess_client.py
@@ -1,0 +1,135 @@
+"""Unit tests for the Chess.com API client wrapper.
+
+The upstream ``ChessDotComClient`` is fully mocked, so these tests exercise
+only our parsing/derivation logic and never hit the network.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from chessdotcom_ai_coach.services.chess_client import Client
+
+PGN_TEMPLATE = (
+    '[White "{white}"]\n'
+    '[Black "{black}"]\n'
+    '[WhiteElo "{white_elo}"]\n'
+    '[BlackElo "{black_elo}"]\n\n'
+    "1. e4 e5 *"
+)
+
+
+def _response(games):
+    """Fake the object returned by the library (exposes a ``.json`` attribute)."""
+    return SimpleNamespace(json={"games": games})
+
+
+def _game(**overrides):
+    game = {
+        "url": "https://www.chess.com/game/daily/944768131",
+        "pgn": PGN_TEMPLATE.format(
+            white="MyUser", black="Opponent", white_elo="1500", black_elo="1600"
+        ),
+        "turn": "white",
+        "fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    }
+    game.update(overrides)
+    return game
+
+
+def _client(response, username="MyUser"):
+    """Build a Client whose underlying API call returns ``response``."""
+    with patch(
+        "chessdotcom_ai_coach.services.chess_client.ChessDotComClient"
+    ) as mock_cls:
+        client = Client(username=username)
+    client._chessdotcomclient.get_player_current_games.return_value = response
+    return client
+
+
+class TestMyCurrentGames:
+    def test_parses_players_and_ratings_from_pgn(self):
+        client = _client(_response([_game()]))
+
+        games = client.my_current_games()
+
+        assert len(games) == 1
+        game = games[0]
+        assert game["white"] == {"username": "MyUser", "rating": "1500"}
+        assert game["black"] == {"username": "Opponent", "rating": "1600"}
+
+    def test_extracts_game_id_from_url(self):
+        client = _client(_response([_game()]))
+
+        game = client.my_current_games()[0]
+
+        assert game["game_id"] == "944768131"
+
+    def test_is_my_turn_true_when_users_side_matches_turn(self):
+        # User plays White and it is White's turn.
+        client = _client(_response([_game(turn="white")]), username="MyUser")
+
+        assert client.my_current_games()[0]["is_my_turn"] is True
+
+    def test_is_my_turn_false_when_opponents_turn(self):
+        # User plays White but it is Black's turn.
+        client = _client(_response([_game(turn="black")]), username="MyUser")
+
+        assert client.my_current_games()[0]["is_my_turn"] is False
+
+    def test_falls_back_to_url_when_pgn_lacks_headers(self):
+        game = _game(
+            pgn="1. e4 e5 *",  # no [White]/[Black] headers
+            white="https://api.chess.com/pub/player/whiteuser",
+            black="https://api.chess.com/pub/player/blackuser",
+        )
+        client = _client(_response([game]))
+
+        parsed = client.my_current_games()[0]
+
+        assert parsed["white"]["username"] == "whiteuser"
+        assert parsed["black"]["username"] == "blackuser"
+        assert parsed["white"]["rating"] == "?"
+        assert parsed["black"]["rating"] == "?"
+
+    def test_defaults_to_unknown_when_no_pgn_and_no_url(self):
+        game = _game(pgn="")
+        game.pop("white", None)
+        game.pop("black", None)
+        client = _client(_response([game]))
+
+        parsed = client.my_current_games()[0]
+
+        assert parsed["white"]["username"] == "Unknown"
+        assert parsed["black"]["username"] == "Unknown"
+
+    def test_returns_empty_list_when_json_is_not_a_dict(self):
+        client = _client(SimpleNamespace(json=None))
+
+        assert client.my_current_games() == []
+
+
+class TestGameDetail:
+    def test_finds_game_by_id_and_parses_names(self):
+        client = _client(_response([_game()]))
+
+        detail = client.game_detail("944768131")
+
+        assert detail is not None
+        assert detail["white_name"] == "MyUser"
+        assert detail["black_name"] == "Opponent"
+        assert detail["game"]["url"].endswith("944768131")
+
+    def test_defaults_names_when_pgn_missing(self):
+        client = _client(_response([_game(pgn="")]))
+
+        detail = client.game_detail("944768131")
+
+        assert detail["white_name"] == "White"
+        assert detail["black_name"] == "Black"
+
+    def test_returns_none_when_id_not_found(self):
+        client = _client(_response([_game()]))
+
+        assert client.game_detail("does-not-exist") is None

--- a/tests/test_coach.py
+++ b/tests/test_coach.py
@@ -1,0 +1,106 @@
+"""Unit tests for the AI coach service.
+
+Both external dependencies are mocked: the LC0 UCI engine (reached via
+``asyncio`` connection) and the Ollama LLM client. Real ``python-chess``
+score objects drive the evaluation-text branches.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import chess
+from chess.engine import Cp, Mate, PovScore
+
+from chessdotcom_ai_coach.services import coach
+
+START_FEN = chess.STARTING_FEN
+E2E4 = chess.Move.from_uci("e2e4")  # legal in the start position -> SAN "e4"
+
+
+@contextmanager
+def _engine(score, move=E2E4, llm_content="LLM analysis text", llm_raises=False):
+    """Patch the engine connection and Ollama client for one call.
+
+    ``score`` is placed in ``result.info["score"]``; ``move`` becomes
+    ``result.move``. If ``llm_raises`` the Ollama chat call raises, forcing
+    the LC0 fallback branch.
+    """
+    engine = MagicMock()
+    engine.play = AsyncMock(return_value=SimpleNamespace(move=move, info={"score": score}))
+    engine.quit = AsyncMock()
+
+    loop = MagicMock()
+    loop.create_connection = AsyncMock(return_value=(MagicMock(), engine))
+
+    ollama_client = MagicMock()
+    if llm_raises:
+        ollama_client.chat = AsyncMock(side_effect=RuntimeError("ollama down"))
+    else:
+        ollama_client.chat = AsyncMock(
+            return_value=SimpleNamespace(message=SimpleNamespace(content=llm_content))
+        )
+
+    with patch.object(coach.asyncio, "get_running_loop", return_value=loop), patch.object(
+        coach.ollama, "AsyncClient", return_value=ollama_client
+    ):
+        yield
+
+
+class TestEvaluationText:
+    """eval_text branches are surfaced through the LC0 fallback string."""
+
+    async def test_mate_for_white(self):
+        with _engine(PovScore(Mate(3), chess.WHITE), llm_raises=True):
+            result = await coach.get_best_move(START_FEN)
+        assert "Decisive advantage for White: Mate in 3 moves." in result
+
+    async def test_mate_for_black(self):
+        with _engine(PovScore(Mate(-3), chess.WHITE), llm_raises=True):
+            result = await coach.get_best_move(START_FEN)
+        assert "Decisive advantage for Black: Mate in 3 moves." in result
+
+    async def test_white_clearly_better(self):
+        with _engine(PovScore(Cp(100), chess.WHITE), llm_raises=True):
+            result = await coach.get_best_move(START_FEN)
+        assert "White is clearly better (+1.00)." in result
+
+    async def test_black_clearly_better(self):
+        with _engine(PovScore(Cp(-100), chess.WHITE), llm_raises=True):
+            result = await coach.get_best_move(START_FEN)
+        assert "Black is clearly better (-1.00)." in result
+
+    async def test_balanced_position(self):
+        with _engine(PovScore(Cp(0), chess.WHITE), llm_raises=True):
+            result = await coach.get_best_move(START_FEN)
+        assert "The position is balanced (+0.00)." in result
+
+    async def test_score_unavailable(self):
+        with _engine(None, llm_raises=True):
+            result = await coach.get_best_move(START_FEN)
+        assert "Analysis unavailable." in result
+
+
+class TestBestMoveAndLLM:
+    async def test_returns_llm_content_on_success(self):
+        with _engine(PovScore(Cp(30), chess.WHITE), llm_content="Play e4, it's great!"):
+            result = await coach.get_best_move(START_FEN)
+        assert result == "Play e4, it's great!"
+
+    async def test_fallback_mentions_lc0_and_san_when_llm_fails(self):
+        with _engine(PovScore(Cp(30), chess.WHITE), llm_raises=True):
+            result = await coach.get_best_move(START_FEN)
+        assert "LC0" in result
+        assert "e4" in result  # SAN of the suggested move
+
+    async def test_no_best_move_identified(self):
+        with _engine(PovScore(Cp(30), chess.WHITE), move=None):
+            result = await coach.get_best_move(START_FEN)
+        assert "No clear best move identified." in result
+
+
+class TestErrorHandling:
+    async def test_invalid_fen_returns_error_string(self):
+        with _engine(PovScore(Cp(0), chess.WHITE)):
+            result = await coach.get_best_move("not-a-valid-fen")
+        assert result.startswith("Error during LC0 analysis:")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,20 @@
+"""Unit tests for the custom User model."""
+
+import pytest
+
+from chessdotcom_ai_coach.models import User
+
+
+@pytest.mark.django_db
+class TestChessUsername:
+    def test_uses_chessdotcom_username_when_set(self):
+        user = User(username="login_name", chessdotcom_username="chess_name")
+        assert user.chess_username == "chess_name"
+
+    def test_falls_back_to_login_username_when_unset(self):
+        user = User(username="login_name", chessdotcom_username=None)
+        assert user.chess_username == "login_name"
+
+    def test_falls_back_to_login_username_when_blank(self):
+        user = User(username="login_name", chessdotcom_username="")
+        assert user.chess_username == "login_name"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,170 @@
+"""Unit tests for the views.
+
+The Chess.com ``Client`` and the async coach are mocked, so no network,
+engine or LLM is touched. A SQLite DB (see conftest) backs auth.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from asgiref.sync import sync_to_async
+
+
+@pytest.fixture
+def user(django_user_model):
+    return django_user_model.objects.create_user(
+        username="MyUser", password="pw12345!"
+    )
+
+
+@pytest.fixture
+def auth_client(client, user):
+    client.force_login(user)
+    return client
+
+
+def _sample_game():
+    return {
+        "game_id": "944768131",
+        "url": "https://www.chess.com/game/daily/944768131",
+        "turn": "white",
+        "time_class": "daily",
+        "time_control": "1/86400",
+        "is_my_turn": True,
+        "white": {"username": "MyUser", "rating": "1500"},
+        "black": {"username": "Opponent", "rating": "1600"},
+        "fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    }
+
+
+@pytest.mark.django_db
+@patch("chessdotcom_ai_coach.views.Client")
+class TestHome:
+    def test_lists_games(self, mock_client, auth_client):
+        mock_client.return_value.my_current_games.return_value = [_sample_game()]
+
+        response = auth_client.get("/")
+
+        assert response.status_code == 200
+        assert list(response.context["games"]) == [_sample_game()]
+
+    def test_renders_error_page_on_failure(self, mock_client, auth_client):
+        mock_client.return_value.my_current_games.side_effect = Exception("boom")
+
+        response = auth_client.get("/")
+
+        assert response.status_code == 500
+        assert b"Something went wrong" in response.content
+
+    def test_requires_login(self, mock_client, client):
+        response = client.get("/")
+
+        assert response.status_code == 302
+        assert "/login" in response["Location"]
+
+
+@pytest.mark.django_db
+@patch("chessdotcom_ai_coach.views.Client")
+class TestGameList:
+    def test_returns_fragment_with_games(self, mock_client, auth_client):
+        mock_client.return_value.my_current_games.return_value = [_sample_game()]
+
+        response = auth_client.get("/games")
+
+        assert response.status_code == 200
+        assert b"Opponent" in response.content
+
+    def test_degrades_silently_to_empty_on_error(self, mock_client, auth_client):
+        mock_client.return_value.my_current_games.side_effect = Exception("boom")
+
+        response = auth_client.get("/games")
+
+        # Polling must not break the page: 200 + empty state, no 500.
+        assert response.status_code == 200
+        assert b"No active games" in response.content
+
+
+@pytest.mark.django_db
+@patch("chessdotcom_ai_coach.views.Client")
+class TestGameDetail:
+    def test_orientation_white_when_user_is_white(self, mock_client, auth_client):
+        mock_client.return_value.game_detail.return_value = {
+            "game": _sample_game(),
+            "white_name": "MyUser",
+            "black_name": "Opponent",
+        }
+
+        response = auth_client.get("/game/944768131")
+
+        assert response.status_code == 200
+        assert response.context["orientation"] == "white"
+
+    def test_orientation_black_when_user_is_black(self, mock_client, auth_client):
+        mock_client.return_value.game_detail.return_value = {
+            "game": _sample_game(),
+            "white_name": "Opponent",
+            "black_name": "MyUser",
+        }
+
+        response = auth_client.get("/game/944768131")
+
+        assert response.context["orientation"] == "black"
+
+    def test_renders_not_found_message(self, mock_client, auth_client):
+        mock_client.return_value.game_detail.return_value = None
+
+        response = auth_client.get("/game/nope")
+
+        assert response.status_code == 200
+        assert b"Game not found" in response.content
+
+    def test_renders_error_page_on_failure(self, mock_client, auth_client):
+        mock_client.return_value.game_detail.side_effect = Exception("boom")
+
+        response = auth_client.get("/game/944768131")
+
+        assert response.status_code == 500
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("chessdotcom_ai_coach.views.get_best_move", new_callable=AsyncMock)
+@patch("chessdotcom_ai_coach.views.Client")
+class TestCoachSuggestion:
+    """coach_suggestion is async, so it is driven through the ASGI async_client."""
+
+    async def test_returns_analysis_fragment(
+        self, mock_client, mock_coach, async_client, user
+    ):
+        await sync_to_async(async_client.force_login)(user)
+        mock_client.return_value.game_detail.return_value = {
+            "game": _sample_game(),
+            "white_name": "MyUser",
+            "black_name": "Opponent",
+        }
+        mock_coach.return_value = "Play e4, a strong central move."
+
+        response = await async_client.get("/game/944768131/coach")
+
+        assert response.status_code == 200
+        assert b"Play e4, a strong central move." in response.content
+
+    async def test_handles_missing_game(
+        self, mock_client, mock_coach, async_client, user
+    ):
+        await sync_to_async(async_client.force_login)(user)
+        mock_client.return_value.game_detail.return_value = None
+
+        response = await async_client.get("/game/nope/coach")
+
+        assert response.status_code == 200
+        assert b"Game not found" in response.content
+        mock_coach.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestLogout:
+    def test_redirects_to_login(self, auth_client):
+        response = auth_client.get("/logout")
+
+        assert response.status_code == 302
+        assert response["Location"] == "/login"

--- a/uv.lock
+++ b/uv.lock
@@ -234,6 +234,13 @@ dependencies = [
     { name = "python-dotenv" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-django" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "chess", specifier = ">=1.11.2" },
@@ -244,6 +251,22 @@ requires-dist = [
     { name = "ollama", specifier = ">=0.6.1,<0.7.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.2,<2.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-django", specifier = ">=4.12.0" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
@@ -405,6 +428,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -505,6 +537,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -683,6 +724,55 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
     { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-django"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/2b/db9a193df89e5660137f5428063bcc2ced7ad790003b26974adf5c5ceb3b/pytest_django-4.12.0.tar.gz", hash = "sha256:df94ec819a83c8979c8f6de13d9cdfbe76e8c21d39473cfe2b40c9fc9be3c758", size = 91156, upload-time = "2026-02-14T18:40:49.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/a5/41d091f697c09609e7ef1d5d61925494e0454ebf51de7de05f0f0a728f1d/pytest_django-4.12.0-py3-none-any.whl", hash = "sha256:3ff300c49f8350ba2953b90297d23bf5f589db69545f56f1ec5f8cff5da83e85", size = 26123, upload-time = "2026-02-14T18:40:47.381Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Sommario

Introduce la prima suite di **unit test** del progetto, basata su **pytest + pytest-django**. La suite è completamente autosufficiente: gira **senza** PostgreSQL, Ollama o l'engine LC0 attivi (DB SQLite temporaneo via `conftest.py` + mock di tutte le dipendenze esterne).

35 test, tutti verdi:

```
uv run pytest
```

## Copertura

- **`services/chess_client.py`** — parsing degli header PGN (White/Black + rating), fallback alla URL, calcolo di `is_my_turn`, estrazione `game_id`, lookup di `game_detail` (nomi di default, `None` se non trovato, lista vuota su payload non-dict).
- **`services/coach.py`** (async) — tutti i rami di `eval_text` (matto Bianco/Nero, "clearly better", "balanced", score assente), ritorno dell'analisi LLM, fallback LC0 quando Ollama fallisce, e gestione dell'eccezione esterna.
- **`models.py`** — property `User.chess_username` con relativo fallback.
- **`views.py`** — redirect di `login_required`, pagine di errore (500), **degrado silenzioso** dell'endpoint di polling `/games`, calcolo dell'orientamento scacchiera, endpoint async `coach_suggestion`, `logout`.

## Bugfix incluso

Scrivendo i test è emerso un bug latente: la view async `coach_suggestion` leggeva `request.user` in modo sincrono, sollevando `SynchronousOnlyOperation` sotto ASGI (l'endpoint del coach era di fatto rotto a runtime). Corretto risolvendo l'utente con `await request.auser()`.

## Note tecniche

- `conftest.py` (root) imposta i default delle env var lette a import-time (es. `CHESS_ENGINE_PORT`) e sostituisce il DB con SQLite su file temporaneo, così i test girano ovunque.
- Config pytest in `pyproject.toml` (`[tool.pytest.ini_options]`, `asyncio_mode = "auto"`).
- Nessuna CI aggiunta (come da accordi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)