### PR TITLE
Auto-refresh game detail page and gate coach analysis by turn

### DIFF
--- a/chessdotcom_ai_coach/templates/base.html
+++ b/chessdotcom_ai_coach/templates/base.html
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{% block title %}Chessdotcom AI Coach{% endblock %}</title>
 
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="{% static 'img/favicon.svg' %}" />
+    <link rel="icon" type="image/png" href="{% static 'img/logo.png' %}" />
+    <link rel="apple-touch-icon" href="{% static 'img/logo.png' %}" />
+
     <!-- HTMX (vendored by django-htmx) -->
     {% htmx_script %}
 

--- a/chessdotcom_ai_coach/templates/partials/board_panel.html
+++ b/chessdotcom_ai_coach/templates/partials/board_panel.html
@@ -11,18 +11,17 @@
     </span>
   </div>
 
-  <!-- Black -->
-  <div class="pbar pbar--top">
-    <span class="pbar__avatar pbar__avatar--b"></span>
-    <span class="pbar__id">
-      <span class="pbar__name">{{ black_name }}</span>
-      <span class="pbar__meta">{{ black_rating|default:"—" }}</span>
-    </span>
-  </div>
+  <!-- Top bar: the player whose pieces sit at the top of the (oriented) board -->
+  {% if orientation == "black" %}
+    {% include "partials/pbar.html" with pos="top" color="w" name=white_name rating=white_rating %}
+  {% else %}
+    {% include "partials/pbar.html" with pos="top" color="b" name=black_name rating=black_rating %}
+  {% endif %}
 
   <!-- Eval bar + board -->
   <div class="board-stage">
-    <div class="evalbar">
+    {% comment %} Flip the eval bar with the board so White's fill stays on White's side. {% endcomment %}
+    <div class="evalbar{% if orientation == "black" %} evalbar--flipped{% endif %}">
       <div class="evalbar__fill" style="height:{{ eval_fill|default:50 }}%"></div>
       <div class="evalbar__mid"></div>
     </div>
@@ -31,14 +30,12 @@
     </div>
   </div>
 
-  <!-- White -->
-  <div class="pbar pbar--bottom">
-    <span class="pbar__avatar pbar__avatar--w"></span>
-    <span class="pbar__id">
-      <span class="pbar__name">{{ white_name }}</span>
-      <span class="pbar__meta">{{ white_rating|default:"—" }}</span>
-    </span>
-  </div>
+  <!-- Bottom bar: the player whose pieces sit at the bottom of the (oriented) board -->
+  {% if orientation == "black" %}
+    {% include "partials/pbar.html" with pos="bottom" color="b" name=black_name rating=black_rating %}
+  {% else %}
+    {% include "partials/pbar.html" with pos="bottom" color="w" name=white_name rating=white_rating %}
+  {% endif %}
 
   <!-- Last move -->
   <div class="movebar">

--- a/chessdotcom_ai_coach/templates/partials/board_panel.html
+++ b/chessdotcom_ai_coach/templates/partials/board_panel.html
@@ -40,11 +40,8 @@
     </span>
   </div>
 
-  <!-- Last move + refresh -->
+  <!-- Last move -->
   <div class="movebar">
     <span class="movebar__last">Last: {{ last_move|default:"—" }}</span>
-    <div class="movebar__nav">
-      <a href="{% url 'game_detail' id %}" title="Reload position" style="color:inherit"><span>&#8635;</span></a>
-    </div>
   </div>
 </div>

--- a/chessdotcom_ai_coach/templates/partials/coach_panel.html
+++ b/chessdotcom_ai_coach/templates/partials/coach_panel.html
@@ -49,11 +49,18 @@
         hx-get="{% url 'coach_suggestion' id %}"
         hx-target="#game-body"
         hx-swap="innerHTML"
+        hx-sync="#game-body:replace"
         hx-disabled-elt="this"
+        {% if not is_user_turn %}disabled{% endif %}
       >
         <span class="coach__prompt-label">
+          {% if not is_user_turn %}
+          <i class="fa-solid fa-hourglass-half"></i>
+          Opponent to move
+          {% else %}
           <i class="fa-solid fa-wand-magic-sparkles"></i>
           {% if analysis %}Re-analyze{% else %}Request suggestion{% endif %}
+          {% endif %}
         </span>
         <span class="htmx-indicator"><span class="spinner"></span> Analyzing…</span>
       </button>

--- a/chessdotcom_ai_coach/templates/partials/game_body.html
+++ b/chessdotcom_ai_coach/templates/partials/game_body.html
@@ -3,6 +3,20 @@
   and re-rendered by the coach_suggestion view (with analysis + board highlight
   + eval fill) to swap #game-body in one shot.
 {% endcomment %}
+{% if can_analyze %}
+{% comment %}
+  Hidden poller: refreshes #game-body while the game is live. Kept OUTSIDE the
+  coach button's subtree so its `htmx-request` class doesn't light up the coach
+  "Analyzing…" indicator. Re-rendered on every swap so `since` tracks the FEN.
+  The server returns 204 (unchanged) / 286 (game over) to skip work and stop.
+{% endcomment %}
+<div hx-get="{% url 'game_detail' id %}?since={{ fen|urlencode }}"
+     hx-trigger="every 5s"
+     hx-target="#game-body"
+     hx-swap="innerHTML"
+     hx-sync="#game-body:drop"
+     hidden></div>
+{% endif %}
 <div class="game-layout">
   {% include "partials/board_panel.html" %}
   {% include "partials/coach_panel.html" %}

--- a/chessdotcom_ai_coach/templates/partials/pbar.html
+++ b/chessdotcom_ai_coach/templates/partials/pbar.html
@@ -1,0 +1,10 @@
+{% comment %}
+  Single player bar. Expects: pos (top|bottom), color (w|b), name, rating.
+{% endcomment %}
+<div class="pbar pbar--{{ pos }}">
+  <span class="pbar__avatar pbar__avatar--{{ color }}"></span>
+  <span class="pbar__id">
+    <span class="pbar__name">{{ name }}</span>
+    <span class="pbar__meta">{{ rating|default:"—" }}</span>
+  </span>
+</div>

--- a/chessdotcom_ai_coach/views.py
+++ b/chessdotcom_ai_coach/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse
 from django.shortcuts import redirect, render
 
 from .models import CoachSuggestion
@@ -58,6 +59,34 @@ def _uci_to_squares(uci):
     return []
 
 
+def _suggestion_for_fen(history, fen):
+    """Return ``(suggestion, highlight)`` for the stored analysis of ``fen``.
+
+    Lets the detail render (and the poll) keep the coach panel populated for the
+    position on the board until a new move changes the FEN. ``(None, None)`` when
+    no analysis exists for the current position.
+    """
+    for row in history:
+        if row.fen == fen:
+            suggestion = {
+                "eval_cp": row.eval_cp,
+                "eval_text": row.eval_text,
+                "best_move_san": row.best_move_san,
+                "best_move_uci": row.best_move_uci,
+                "analysis": row.analysis,
+            }
+            return suggestion, _uci_to_squares(row.best_move_uci)
+    return None, None
+
+
+def _is_user_turn(game_data, username):
+    """True when the side to move is the side the user plays."""
+    orientation = (
+        "white" if game_data["white_name"].lower() == username.lower() else "black"
+    )
+    return board_utils.active_color(game_data["game"].get("fen")) == orientation
+
+
 def _eval_fill(eval_cp):
     """Map a White-POV centipawn eval to the eval bar's white fill percentage."""
     if eval_cp is None:
@@ -93,6 +122,9 @@ def _build_detail_context(
     moves = board_utils.moves_from_pgn(pgn)
     board_utils.annotate_moves(moves, history)
 
+    active = board_utils.active_color(fen)
+    is_user_turn = active == orientation
+
     return {
         "id": id,
         "game": game,
@@ -107,7 +139,8 @@ def _build_detail_context(
             fen, highlight=highlight, flipped=(orientation == "black")
         ),
         "move_no": board_utils.fullmove_number(fen),
-        "turn_label": board_utils.active_color(fen).capitalize(),
+        "turn_label": active.capitalize(),
+        "is_user_turn": is_user_turn,
         "last_move": board_utils.last_move_from_pgn(pgn),
         "analysis": analysis,
         "eval_fill": _eval_fill(suggestion["eval_cp"]) if suggestion else 50,
@@ -168,24 +201,47 @@ def game_detail(request, id):
     try:
         game_data, error = _fetch_detail(request.user, id)
     except Exception as exc:
+        if request.htmx:
+            # Transient fetch failure during a poll: skip this cycle, keep polling.
+            return HttpResponse(status=204)
         return render(request, "error.html", {"message": str(exc)}, status=500)
 
     can_analyze = True
     if error:
         stored = game_store.stored_game(request.user, id)
         if stored is None:
+            if request.htmx:
+                return HttpResponse(status=286)  # nothing to poll for: stop the poll
             return render(request, "game.html", {"id": id, "error": error})
         game_data = _game_data_from_stored(stored)
         can_analyze = False  # past game: history is read-only
 
+    fen = game_data["game"].get("fen")
+
+    # HTMX poll (hidden poller inside #game-body) bookkeeping:
+    if request.htmx:
+        if not can_analyze:
+            # Game is no longer live -> HTTP 286 tells HTMX to stop polling.
+            return HttpResponse(status=286)
+        if request.GET.get("since") == fen:
+            # Position unchanged -> no swap, leave the DOM (and analysis) untouched.
+            return HttpResponse(status=204)
+
     history = list(CoachSuggestion.objects.filter(user=request.user, game_id=id))
+    suggestion, highlight = _suggestion_for_fen(history, fen)
     context = _build_detail_context(
         game_data,
         request.user.chess_username,
         id,
+        highlight=highlight,
+        analysis=suggestion["analysis"] if suggestion else None,
+        suggestion=suggestion,
         history=history,
         can_analyze=can_analyze,
     )
+    if request.htmx:
+        # Position changed since the client's `since` -> swap the fresh body.
+        return render(request, "partials/game_body.html", context)
     return render(request, "game.html", context)
 
 
@@ -208,6 +264,26 @@ async def coach_suggestion(request, id):
 
     game = game_data["game"]
     fen = game.get("fen", "")
+
+    if not _is_user_turn(game_data, user.chess_username):
+        # The button was stale (opponent moved before the poll refreshed): skip the
+        # analysis and re-render the body, which now shows the button disabled.
+        history = [
+            s async for s in CoachSuggestion.objects.filter(user=user, game_id=id)
+        ]
+        stored, highlight = _suggestion_for_fen(history, fen)
+        context = _build_detail_context(
+            game_data,
+            user.chess_username,
+            id,
+            highlight=highlight,
+            analysis=stored["analysis"] if stored else None,
+            suggestion=stored,
+            history=history,
+            can_analyze=True,
+        )
+        return render(request, "partials/game_body.html", context)
+
     suggestion = await get_best_move(fen, game.get("pgn"))
     highlight = _uci_to_squares(suggestion["best_move_uci"])
 

--- a/theme/static/css/styles.css
+++ b/theme/static/css/styles.css
@@ -349,8 +349,12 @@ input {
   box-shadow: inset 0 0 0 1.3cqw rgba(183, 142, 84, 0.92);
 }
 .board__pc {
-  font-size: 10cqw;
+  font-size: 11.5cqw;
   line-height: 1;
+  /* Unicode chess glyphs carry extra metric space below the baseline, so the
+     ink sits high in the line box; nudge it down to optically centre the piece. */
+  display: block;
+  transform: translateY(12%);
   font-family: "Segoe UI Symbol", "Noto Sans Symbols2", "Arial Unicode MS", serif;
 }
 .board__pc--w {
@@ -579,6 +583,11 @@ input {
   position: relative;
   flex: none;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
+/* Board flipped for a black-perspective view: flip the bar too so White's
+   fill grows from White's (now top) side. */
+.evalbar--flipped {
+  transform: scaleY(-1);
 }
 .evalbar__fill {
   position: absolute;

--- a/theme/static/img/favicon.svg
+++ b/theme/static/img/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#4a7a52"/>
+  <text x="16" y="24" font-family="Georgia, 'Times New Roman', serif" font-size="24" text-anchor="middle" fill="#fbf8f0">&#9818;</text>
+</svg>


### PR DESCRIPTION
## Context

The game detail page was fully static: it only changed on a manual click of the "Reload position" link or the coach button. This PR makes a live game's detail page keep itself up to date, and restricts coach analysis to the user's turn.

## Changes

### Auto-refresh (polling)
- A dedicated **hidden poller** inside `#game-body` refreshes the body every 5s. It is deliberately kept **outside the coach button's subtree** so its `htmx-request` class no longer lights up the "Analyzing…" indicator on every poll.
- `game_detail` returns the `game_body` fragment for HTMX requests and uses HTTP status codes to keep polls cheap and non-disruptive:
  - **204** when the position is unchanged (`?since=<fen>`) → no DOM swap, client state preserved.
  - **286** when the game is no longer live → HTMX stops polling automatically.
  - **204** on transient fetch errors → skip this cycle, keep polling.
- The stored coach analysis for the current FEN is restored on render (`_suggestion_for_fen`), so it persists across polls until a new move changes the position.
- Poll and coach button share the `#game-body` `hx-sync` group (poll: `drop`, coach: `replace`) so a poll never clobbers an in-flight analysis.
- Removed the now-redundant manual "Reload position" link.

### Coach analysis gated by turn
- The button is **disabled** and shows "Opponent to move" when it is not the user's turn (`is_user_turn` in the detail context).
- `coach_suggestion` also **guards server-side**: if it is not the user's turn it re-renders the body without running the engine, closing the race where the button was still enabled right after the user moved.

## Verification
1. Open a **live** game: board / moves / data refresh on their own; Network shows `204` while idle and a fragment swap only when a move is played.
2. Request a suggestion: analysis persists across polls (same FEN) and clears when the position changes; a long analysis is not interrupted by polls.
3. On the **opponent's turn** the button is disabled ("Opponent to move") and re-enables automatically after they move.
4. When the game ends, polling stops (`286`).
5. Open a **past** game: no polling, static page, no reload link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)