### PR TITLE
Show the app version in a shared footer badge

### DIFF
--- a/chessdotcom_ai_coach/templates/base.html
+++ b/chessdotcom_ai_coach/templates/base.html
@@ -52,5 +52,9 @@
     {% endblock %}
 
     {% block content %}{% endblock %}
+
+    {% block footer %}
+    <footer class="app-footer">v{{ version }}</footer>
+    {% endblock %}
   </body>
 </html>

--- a/theme/static/css/styles.css
+++ b/theme/static/css/styles.css
@@ -199,6 +199,24 @@ input {
   background: #e8635a;
 }
 
+/* ===================== App footer (fixed version badge) =============== */
+.app-footer {
+  position: fixed;
+  bottom: 10px;
+  right: 14px;
+  z-index: 5;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--ink-faint);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  padding: 3px 9px;
+  pointer-events: none;
+  user-select: none;
+}
+
 .user-chip {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- The app version was already computed (`APP_VERSION` in `settings.py`) and exposed to every template via the `app_version` context processor, but no template rendered it, so it was invisible in the UI.
- Add a small fixed-position version badge (`v{{ version }}`) in `base.html`, shared by every page since all top-level templates extend it.
- Style it as an unobtrusive, non-interactive badge (`.app-footer` in `theme/static/css/styles.css`) so it doesn't disturb the login split-panel layout or the fixed-height game/board layouts.

## Test plan
- [x] Rendered `login.html` and an authenticated page (via a local sqlite-backed dev server + headless Chromium) and visually confirmed the version badge (`v1.1.0`) shows bottom-right without overlapping the header, board, or login form.


---
_Generated by [Claude Code](https://claude.ai/code/session_016w7oGrD3Ftn8oj1LEkjKRq)_