### PR TITLE
Fix scheduler to sync games from Chess.com instead of relying on browser polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ grandmaster coach.
 - **Celery + Redis** — game analysis runs out-of-band: the view enqueues a Celery
   task (`chessdotcom_ai_coach/tasks.py`) with Redis as broker and result backend;
   a hidden HTMX poller reveals the result once the worker finishes
-- **APScheduler** — background scheduler (`manage.py run_scheduler`) that polls
-  active games every second and auto-enqueues analysis when it's the user's turn
-  (`chessdotcom_ai_coach/services/scheduler.py`); runs once inside the web container
-- **HTMX** — on-demand game loading and polling for the async coach result,
-  vendored via `django-htmx`
+- **APScheduler** — background scheduler (`manage.py run_scheduler`) that, every
+  5 seconds, syncs each linked user's current games from Chess.com into the
+  local DB and then auto-enqueues analysis when it's the user's turn
+  (`chessdotcom_ai_coach/services/scheduler.py`); runs once inside the web
+  container. This is the only path that keeps game data fresh — the home page
+  (below) just reads what the scheduler already synced.
+- **HTMX** — on-demand game loading and polling for the game list (a plain DB
+  read — see above) and for the async coach result, vendored via `django-htmx`
 - **Alpine.js** — board rendering (loaded from CDN, only on the game page)
 - **Gunicorn** — WSGI server in the container
 - Custom hand-written CSS theme (no Tailwind) in the `theme` app

--- a/chessdotcom_ai_coach/management/commands/run_scheduler.py
+++ b/chessdotcom_ai_coach/management/commands/run_scheduler.py
@@ -1,9 +1,16 @@
-"""Run the APScheduler that polls for games due for analysis every 1 second.
+"""Run the APScheduler that syncs games from Chess.com and enqueues analysis.
 
 This is the single source of scheduling in the project (there is no Celery Beat).
 Run it as its own process/service so exactly one scheduler instance exists — an
 in-process scheduler under gunicorn would start once per worker and enqueue
 duplicates.
+
+Every tick (5s — matching the home page's own HTMX poll cadence, so nothing
+needs data fresher than that) first syncs each linked user's current games
+from Chess.com into the local DB (`sync_current_games`), then checks that DB
+for games due for analysis and enqueues them (`enqueue_due_analyses`). The two
+steps run in separate try/except blocks so a Chess.com outage doesn't stop the
+local enqueue check from still running against whatever `Game` rows exist.
 """
 
 import logging
@@ -11,24 +18,28 @@ import logging
 from apscheduler.schedulers.blocking import BlockingScheduler
 from django.core.management.base import BaseCommand
 
-from ...services.scheduler import enqueue_due_analyses
+from ...services.scheduler import enqueue_due_analyses, sync_current_games
 
 logger = logging.getLogger(__name__)
 
+POLL_INTERVAL_SECONDS = 5
+
 
 class Command(BaseCommand):
-    help = "Poll active games every second and enqueue Celery analysis tasks."
+    help = "Every 5s, sync games from Chess.com and enqueue Celery analysis tasks."
 
     def handle(self, *args, **options):
         scheduler = BlockingScheduler()
         scheduler.add_job(
             self._tick,
             "interval",
-            seconds=1,
+            seconds=POLL_INTERVAL_SECONDS,
             max_instances=1,  # never overlap a slow tick with the next
             coalesce=True,  # collapse missed runs into one
         )
-        self.stdout.write(self.style.SUCCESS("Scheduler started (1s poll)."))
+        self.stdout.write(
+            self.style.SUCCESS(f"Scheduler started ({POLL_INTERVAL_SECONDS}s poll).")
+        )
         try:
             scheduler.start()
         except (KeyboardInterrupt, SystemExit):
@@ -36,6 +47,10 @@ class Command(BaseCommand):
 
     def _tick(self):
         try:
-            enqueue_due_analyses()
+            sync_current_games()
         except Exception:  # a bad tick must not kill the scheduler
+            logger.exception("Chess.com sync failed")
+        try:
+            enqueue_due_analyses()
+        except Exception:
             logger.exception("Scheduler tick failed")

--- a/chessdotcom_ai_coach/services/game_store.py
+++ b/chessdotcom_ai_coach/services/game_store.py
@@ -56,6 +56,11 @@ def upsert_current_games(user, games: List[dict]) -> None:
     )
 
 
+def current_games(user) -> List[Game]:
+    """Active games for the user (for the home page's live-games section)."""
+    return list(Game.objects.filter(user=user, is_active=True))
+
+
 def past_games(user) -> List[Game]:
     """Games that are no longer current, newest first (for the home history)."""
     return list(Game.objects.filter(user=user, is_active=False))

--- a/chessdotcom_ai_coach/services/scheduler.py
+++ b/chessdotcom_ai_coach/services/scheduler.py
@@ -1,13 +1,19 @@
-"""Scheduler poll body: select games due for analysis and enqueue Celery tasks.
-
-Kept separate from the management command so it can be unit-tested without a
-running APScheduler. Reads only the local DB (no Chess.com API call), so a 1s
-poll is a single indexed query over active games.
+"""Scheduler tick body, split into its two steps so each is unit-testable
+without a running APScheduler: `sync_current_games` pulls each linked user's
+games from Chess.com into the local DB, and `enqueue_due_analyses` selects
+games due for analysis from that local DB and enqueues Celery tasks.
+`run_scheduler` calls them back-to-back on every tick.
 """
 
-from ..models import CoachSuggestion, Game
+import logging
+
+from ..models import CoachSuggestion, Game, User
 from ..tasks import analyze_game_task
 from . import board as board_utils
+from . import game_store
+from .chess_client import Client
+
+logger = logging.getLogger(__name__)
 
 
 def _user_color(game: Game) -> str | None:
@@ -24,6 +30,27 @@ def _is_user_turn(game: Game) -> bool:
     """True when the side to move in `game.fen` is the side the user plays."""
     color = _user_color(game)
     return color is not None and board_utils.active_color(game.fen) == color
+
+
+def sync_current_games() -> None:
+    """Refresh linked users' current games from Chess.com into the local DB.
+
+    This is the only path that keeps `Game` fresh now that the home page is a
+    plain DB read (see `views.home`/`views.game_list`) — without it, `Game`
+    rows would never advance and `enqueue_due_analyses` would keep checking a
+    stale FEN. Only users who explicitly linked a Chess.com account are
+    synced. A per-user failure (bad username, transient network error) is
+    logged and skipped so it doesn't block the rest of the batch.
+    """
+    users = User.objects.filter(is_active=True).exclude(
+        chessdotcom_username__isnull=True
+    ).exclude(chessdotcom_username="")
+    for user in users:
+        try:
+            games = Client(username=user.chess_username).my_current_games()
+            game_store.upsert_current_games(user, games)
+        except Exception:
+            logger.exception("Chess.com sync failed for user %s", user.chess_username)
 
 
 def enqueue_due_analyses() -> int:

--- a/chessdotcom_ai_coach/templates/partials/game_list.html
+++ b/chessdotcom_ai_coach/templates/partials/game_list.html
@@ -23,8 +23,8 @@
     <div class="gm-card__player">
       <span class="gm-card__avatar gm-card__avatar--b"></span>
       <span class="gm-card__id">
-        <span class="gm-card__name">{{ game.black.username }}</span>
-        <span class="gm-card__meta">{{ game.black.rating }}</span>
+        <span class="gm-card__name">{{ game.black_name }}</span>
+        <span class="gm-card__meta">{{ game.black_rating|default:"—" }}</span>
       </span>
       {% if game.turn == 'black' %}<span class="gm-card__turn">to move</span>{% endif %}
     </div>
@@ -40,8 +40,8 @@
     <div class="gm-card__player gm-card__player--white">
       <span class="gm-card__avatar gm-card__avatar--w"></span>
       <span class="gm-card__id">
-        <span class="gm-card__name">{{ game.white.username }}</span>
-        <span class="gm-card__meta">{{ game.white.rating }}</span>
+        <span class="gm-card__name">{{ game.white_name }}</span>
+        <span class="gm-card__meta">{{ game.white_rating|default:"—" }}</span>
       </span>
       {% if game.turn == 'white' %}<span class="gm-card__turn">to move</span>{% endif %}
     </div>

--- a/chessdotcom_ai_coach/views.py
+++ b/chessdotcom_ai_coach/views.py
@@ -17,19 +17,17 @@ def _client_for(user) -> Client:
 
 
 def _decorate_games(games):
-    """Attach the glyph-board cells and move number used by the game cards."""
-    for game in games:
-        fen = game.get("fen")
-        game["cells"] = board_utils.fen_to_cells(fen)
-        game["move_no"] = board_utils.fullmove_number(fen)
-    return games
+    """Attach board cells, move number and side-to-move to `Game` rows.
 
-
-def _decorate_past_games(games):
-    """Attach board cells + move number to persisted Game rows (history cards)."""
+    Used for both the current and past-games sections of the home page (both
+    now plain DB reads — see `home`/`game_list`). `turn` reproduces the
+    side-to-move the Chess.com API used to supply directly, derived from the
+    stored FEN, so the game card's "to move" tag keeps working.
+    """
     for game in games:
         game.cells = board_utils.fen_to_cells(game.fen)
         game.move_no = board_utils.fullmove_number(game.fen)
+        game.turn = board_utils.active_color(game.fen)
     return games
 
 
@@ -183,14 +181,13 @@ def _fetch_detail(user, id):
 
 @login_required
 def home(request):
-    """Home page: lists the user's current games plus the past-games history."""
-    try:
-        games = _decorate_games(_client_for(request.user).my_current_games())
-        game_store.upsert_current_games(request.user, games)
-    except Exception as exc:
-        return render(request, "error.html", {"message": str(exc)}, status=500)
+    """Home page: lists the user's current games plus the past-games history.
 
-    past = _decorate_past_games(game_store.past_games(request.user))
+    Plain DB read — the scheduler (`services.scheduler.sync_current_games`)
+    is the only path that pulls fresh data from Chess.com into `Game`.
+    """
+    games = _decorate_games(game_store.current_games(request.user))
+    past = _decorate_games(game_store.past_games(request.user))
     return render(request, "home.html", {"games": games, "past_games": past})
 
 
@@ -198,15 +195,11 @@ def home(request):
 def game_list(request):
     """HTMX endpoint: current games + past-games history fragment for polling.
 
-    Snapshots the current games on every poll so the history stays fresh even
-    without opening a game.
+    Plain DB read, same as `home` — the scheduler keeps `Game` fresh, so the
+    5s poll here never has to touch Chess.com itself.
     """
-    try:
-        games = _decorate_games(_client_for(request.user).my_current_games())
-        game_store.upsert_current_games(request.user, games)
-    except Exception:
-        games = []  # degrada silenziosamente: il polling non deve rompere la pagina
-    past = _decorate_past_games(game_store.past_games(request.user))
+    games = _decorate_games(game_store.current_games(request.user))
+    past = _decorate_games(game_store.past_games(request.user))
     return render(
         request, "partials/game_list.html", {"games": games, "past_games": past}
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chessdotcom-ai-coach"
-version = "1.1.0"
+version = "1.2.0"
 description = ""
 authors = [
     { name = "gab-25", email = "gabrielesorci.25@gmail.com" }

--- a/tests/test_game_store.py
+++ b/tests/test_game_store.py
@@ -58,6 +58,13 @@ class TestUpsertCurrentGames:
 
 @pytest.mark.django_db
 class TestQueries:
+    def test_current_games_returns_only_active(self, user):
+        Game.objects.create(user=user, game_id="active", is_active=True)
+        Game.objects.create(user=user, game_id="past", is_active=False)
+
+        current = game_store.current_games(user)
+        assert [g.game_id for g in current] == ["active"]
+
     def test_past_games_returns_only_inactive(self, user):
         Game.objects.create(user=user, game_id="active", is_active=True)
         Game.objects.create(user=user, game_id="past", is_active=False)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,15 +1,19 @@
-"""Unit tests for the scheduler poll body (`enqueue_due_analyses`).
+"""Unit tests for the scheduler tick body: `sync_current_games` (Chess.com ->
+DB) and `enqueue_due_analyses` (DB -> Celery).
 
-The Celery task is mocked, so no broker or worker is needed: we assert only which
-games get enqueued and that dedup prevents re-enqueuing a queued position.
+The Celery task and the Chess.com `Client` are mocked, so no broker, worker or
+network is needed.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from chessdotcom_ai_coach.models import CoachSuggestion, Game
-from chessdotcom_ai_coach.services.scheduler import enqueue_due_analyses
+from chessdotcom_ai_coach.services.scheduler import (
+    enqueue_due_analyses,
+    sync_current_games,
+)
 
 # White to move (FEN field 2 = "w") vs. black to move.
 WHITE_TO_MOVE = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
@@ -102,3 +106,84 @@ class TestEnqueueDueAnalyses:
 
         assert enqueued == 1
         mock_task.delay.assert_called_once()
+
+
+@pytest.mark.django_db
+@patch("chessdotcom_ai_coach.services.scheduler.game_store.upsert_current_games")
+@patch("chessdotcom_ai_coach.services.scheduler.Client")
+class TestSyncCurrentGames:
+    def test_syncs_user_with_linked_chess_username(
+        self, mock_client_cls, mock_upsert, django_user_model
+    ):
+        user = django_user_model.objects.create_user(
+            username="login_name",
+            password="pw12345!",
+            chessdotcom_username="ChessHandle",
+        )
+        mock_client_cls.return_value.my_current_games.return_value = ["game-dict"]
+
+        sync_current_games()
+
+        mock_client_cls.assert_called_once_with(username="ChessHandle")
+        mock_upsert.assert_called_once_with(user, ["game-dict"])
+
+    def test_skips_user_without_linked_username(
+        self, mock_client_cls, mock_upsert, django_user_model
+    ):
+        # No chessdotcom_username set: chess_username would fall back to the
+        # login username, but this user is intentionally not synced.
+        django_user_model.objects.create_user(username="login_name", password="pw12345!")
+
+        sync_current_games()
+
+        mock_client_cls.assert_not_called()
+        mock_upsert.assert_not_called()
+
+    def test_skips_user_with_blank_linked_username(
+        self, mock_client_cls, mock_upsert, django_user_model
+    ):
+        django_user_model.objects.create_user(
+            username="login_name", password="pw12345!", chessdotcom_username=""
+        )
+
+        sync_current_games()
+
+        mock_client_cls.assert_not_called()
+        mock_upsert.assert_not_called()
+
+    def test_skips_inactive_user(self, mock_client_cls, mock_upsert, django_user_model):
+        django_user_model.objects.create_user(
+            username="login_name",
+            password="pw12345!",
+            chessdotcom_username="ChessHandle",
+            is_active=False,
+        )
+
+        sync_current_games()
+
+        mock_client_cls.assert_not_called()
+        mock_upsert.assert_not_called()
+
+    def test_one_users_failure_does_not_block_the_rest(
+        self, mock_client_cls, mock_upsert, django_user_model
+    ):
+        django_user_model.objects.create_user(
+            username="bad_login", password="pw12345!", chessdotcom_username="Bad"
+        )
+        good_user = django_user_model.objects.create_user(
+            username="good_login", password="pw12345!", chessdotcom_username="Good"
+        )
+
+        def _client_for(username):
+            client = MagicMock()
+            if username == "Bad":
+                client.my_current_games.side_effect = Exception("boom")
+            else:
+                client.my_current_games.return_value = ["ok"]
+            return client
+
+        mock_client_cls.side_effect = _client_for
+
+        sync_current_games()  # must not raise
+
+        mock_upsert.assert_called_once_with(good_user, ["ok"])

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -40,30 +40,36 @@ def _sample_game():
 
 
 @pytest.mark.django_db
-@patch("chessdotcom_ai_coach.views.Client")
 class TestHome:
-    def test_lists_games(self, mock_client, auth_client):
-        mock_client.return_value.my_current_games.return_value = [_sample_game()]
+    def test_lists_games(self, auth_client, user):
+        Game.objects.create(
+            user=user,
+            game_id="944768131",
+            white_name="MyUser",
+            black_name="Opponent",
+            fen="rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            is_active=True,
+        )
 
         response = auth_client.get("/")
 
         assert response.status_code == 200
         games = list(response.context["games"])
         assert len(games) == 1
-        assert games[0]["game_id"] == "944768131"
+        assert games[0].game_id == "944768131"
         # The view enriches each game with the glyph board + move number.
-        assert len(games[0]["cells"]) == 64
-        assert games[0]["move_no"] == 1
+        assert len(games[0].cells) == 64
+        assert games[0].move_no == 1
 
-    def test_renders_error_page_on_failure(self, mock_client, auth_client):
-        mock_client.return_value.my_current_games.side_effect = Exception("boom")
+    def test_does_not_call_chess_com(self, auth_client):
+        # Home is a plain DB read now — the scheduler owns Chess.com syncing.
+        with patch("chessdotcom_ai_coach.views.Client") as mock_client:
+            response = auth_client.get("/")
 
-        response = auth_client.get("/")
+        assert response.status_code == 200
+        mock_client.assert_not_called()
 
-        assert response.status_code == 500
-        assert b"Something went wrong" in response.content
-
-    def test_requires_login(self, mock_client, client):
+    def test_requires_login(self, client):
         response = client.get("/")
 
         assert response.status_code == 302
@@ -71,34 +77,29 @@ class TestHome:
 
 
 @pytest.mark.django_db
-@patch("chessdotcom_ai_coach.views.Client")
 class TestGameList:
-    def test_returns_fragment_with_games(self, mock_client, auth_client):
-        mock_client.return_value.my_current_games.return_value = [_sample_game()]
+    def test_returns_fragment_with_games(self, auth_client, user):
+        Game.objects.create(
+            user=user,
+            game_id="944768131",
+            white_name="MyUser",
+            black_name="Opponent",
+            fen="rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            is_active=True,
+        )
 
         response = auth_client.get("/games")
 
         assert response.status_code == 200
         assert b"Opponent" in response.content
 
-    def test_degrades_silently_to_empty_on_error(self, mock_client, auth_client):
-        mock_client.return_value.my_current_games.side_effect = Exception("boom")
-
-        response = auth_client.get("/games")
-
-        # Polling must not break the page: 200 + empty state, no 500.
-        assert response.status_code == 200
-        assert b"No active games" in response.content
-
-    def test_persists_current_games_on_poll(self, mock_client, auth_client, user):
-        mock_client.return_value.my_current_games.return_value = [_sample_game()]
-
+    def test_does_not_write_to_the_db(self, auth_client, user):
+        # No upsert happens here anymore — that's the scheduler's job now.
         auth_client.get("/games")
 
-        assert Game.objects.filter(user=user, game_id="944768131", is_active=True).exists()
+        assert not Game.objects.filter(user=user).exists()
 
-    def test_renders_past_games_section(self, mock_client, auth_client, user):
-        mock_client.return_value.my_current_games.return_value = []
+    def test_renders_past_games_section(self, auth_client, user):
         Game.objects.create(
             user=user, game_id="old1", black_name="PastFoe", is_active=False
         )

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "chessdotcom-ai-coach"
-version = "1.1.0"
+version = "1.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
The scheduler only ever read the local Game table; that table was refreshed
from Chess.com solely by the home page's browser-driven polling, so without an
open tab the scheduler kept checking a stale FEN and never enqueued analysis
for opponent moves or new games.

Add scheduler.sync_current_games(), which pulls each linked user's current
games from Chess.com into the DB, and run it before enqueue_due_analyses() on
every 5s scheduler tick (matching the home page's own poll cadence, so a
faster local-only tick bought nothing). The home page (views.home/game_list)
now just reads Game from the DB instead of also hitting Chess.com on every
poll, since the scheduler is the sole sync path.