### PR TITLE
Highlight games where it's the user's turn on the home page

### DIFF
--- a/chessdotcom_ai_coach/templates/home.html
+++ b/chessdotcom_ai_coach/templates/home.html
@@ -17,7 +17,7 @@
       </p>
     </div>
     <div class="home__filters">
-      <span class="filter-chip">Sort: Rating &#9662;</span>
+      <span class="filter-chip">Sort: Most recent &#9662;</span>
       <span class="filter-chip">All time controls &#9662;</span>
     </div>
   </div>

--- a/chessdotcom_ai_coach/templates/partials/game_list.html
+++ b/chessdotcom_ai_coach/templates/partials/game_list.html
@@ -10,9 +10,14 @@
   </div>
   {% else %}
   {% for game in games %}
-  <a href="{% url 'game_detail' game.game_id %}" class="gm-card">
+  <a href="{% url 'game_detail' game.game_id %}" class="gm-card{% if game.is_user_turn %} gm-card--your-turn{% endif %}">
     <div class="gm-card__head">
-      <span class="badge">{{ game.time_class|capfirst }}</span>
+      <span class="gm-card__head-left">
+        <span class="badge">{{ game.time_class|capfirst }}</span>
+        {% if game.is_user_turn %}
+        <span class="badge badge--turn"><i class="fa-solid fa-bell"></i>Your turn</span>
+        {% endif %}
+      </span>
       <span class="gm-card__live">
         <span class="badge badge--live"><span class="badge__dot"></span></span>
         LIVE{% if game.move_no %} · move {{ game.move_no }}{% endif %}

--- a/chessdotcom_ai_coach/views.py
+++ b/chessdotcom_ai_coach/views.py
@@ -16,18 +16,22 @@ def _client_for(user) -> Client:
     return Client(username=user.chess_username)
 
 
-def _decorate_games(games):
-    """Attach board cells, move number and side-to-move to `Game` rows.
+def _decorate_games(games, username):
+    """Attach board cells, move number, side-to-move and turn ownership to `Game` rows.
 
     Used for both the current and past-games sections of the home page (both
     now plain DB reads — see `home`/`game_list`). `turn` reproduces the
     side-to-move the Chess.com API used to supply directly, derived from the
-    stored FEN, so the game card's "to move" tag keeps working.
+    stored FEN, so the game card's "to move" tag keeps working. `is_user_turn`
+    mirrors `_is_user_turn` so the list can highlight games awaiting the
+    logged-in user's move.
     """
     for game in games:
         game.cells = board_utils.fen_to_cells(game.fen)
         game.move_no = board_utils.fullmove_number(game.fen)
         game.turn = board_utils.active_color(game.fen)
+        orientation = "white" if game.white_name.lower() == username.lower() else "black"
+        game.is_user_turn = game.turn == orientation
     return games
 
 
@@ -186,8 +190,9 @@ def home(request):
     Plain DB read — the scheduler (`services.scheduler.sync_current_games`)
     is the only path that pulls fresh data from Chess.com into `Game`.
     """
-    games = _decorate_games(game_store.current_games(request.user))
-    past = _decorate_games(game_store.past_games(request.user))
+    username = request.user.chess_username
+    games = _decorate_games(game_store.current_games(request.user), username)
+    past = _decorate_games(game_store.past_games(request.user), username)
     return render(request, "home.html", {"games": games, "past_games": past})
 
 
@@ -198,8 +203,9 @@ def game_list(request):
     Plain DB read, same as `home` — the scheduler keeps `Game` fresh, so the
     5s poll here never has to touch Chess.com itself.
     """
-    games = _decorate_games(game_store.current_games(request.user))
-    past = _decorate_games(game_store.past_games(request.user))
+    username = request.user.chess_username
+    games = _decorate_games(game_store.current_games(request.user), username)
+    past = _decorate_games(game_store.past_games(request.user), username)
     return render(
         request, "partials/game_list.html", {"games": games, "past_games": past}
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chessdotcom-ai-coach"
-version = "1.2.0"
+version = "1.3.0"
 description = ""
 authors = [
     { name = "gab-25", email = "gabrielesorci.25@gmail.com" }

--- a/theme/static/css/styles.css
+++ b/theme/static/css/styles.css
@@ -332,6 +332,13 @@ input {
   background: var(--live-red);
   animation: gm-pulse 1.6s infinite;
 }
+.badge--turn {
+  color: var(--chrome);
+  background: var(--brass);
+}
+.badge--turn i {
+  font-size: 9px;
+}
 
 /* ===================== Chessboard (glyph) ===================== */
 .board {
@@ -442,12 +449,24 @@ input {
   box-shadow: var(--shadow-lift);
   color: inherit;
 }
+.gm-card--your-turn {
+  border-color: var(--brass);
+  box-shadow: 0 0 0 2px rgba(183, 142, 84, 0.35), var(--shadow-card);
+}
+.gm-card--your-turn:hover {
+  box-shadow: 0 0 0 2px rgba(183, 142, 84, 0.45), var(--shadow-lift);
+}
 .gm-card__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
   border-bottom: 1px solid var(--line-soft);
+}
+.gm-card__head-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .gm-card__live {
   display: inline-flex;

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "chessdotcom-ai-coach"
-version = "1.2.0"
+version = "1.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Closes #29

Extend _decorate_games to compute is_user_turn (reusing the existing
_is_user_turn orientation logic) and surface it in the game list as a
"Your turn" badge plus a brass accent on the card itself, so it's easy
to spot at a glance which current games are waiting on the user.