### PR TITLE
Sync board arrow and eval bar when analysis result arrives

### DIFF
--- a/chessdotcom_ai_coach/templates/partials/_arrows_svg.html
+++ b/chessdotcom_ai_coach/templates/partials/_arrows_svg.html
@@ -1,0 +1,15 @@
+{% comment %}
+  The board arrow overlay. Always rendered (even with no arrows) so its id is a
+  stable target: position.html renders it inline; the coach-card self-poll
+  renders it standalone with an out-of-band swap (`oob`), so a freshly-arrived
+  analysis draws its arrows — or an empty overlay clears stale ones — without a
+  full #gr-view re-render.
+{% endcomment %}<svg id="gr-arrows"{% if oob %} hx-swap-oob="true"{% endif %} class="gr-arrows" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="gr-ah-brass" markerWidth="4" markerHeight="4" refX="2.4" refY="2" orient="auto"><path d="M0,0 L4,2 L0,4 z" fill="#b78e54"></path></marker>
+    <marker id="gr-ah-green" markerWidth="4" markerHeight="4" refX="2.4" refY="2" orient="auto"><path d="M0,0 L4,2 L0,4 z" fill="#4a7a52"></path></marker>
+  </defs>
+  {% for a in arrows %}
+  <line x1="{{ a.x1 }}%" y1="{{ a.y1 }}%" x2="{{ a.x2 }}%" y2="{{ a.y2 }}%" stroke="{{ a.color }}" stroke-width="7" stroke-linecap="round" opacity="0.92" marker-end="{{ a.marker }}"></line>
+  {% endfor %}
+</svg>

--- a/chessdotcom_ai_coach/templates/partials/_evalfill.html
+++ b/chessdotcom_ai_coach/templates/partials/_evalfill.html
@@ -1,0 +1,5 @@
+{% comment %}
+  The eval-bar fill. Rendered inline by position.html and, on its own with an
+  out-of-band swap, by the coach-card self-poll (`oob`) so the bar tracks a
+  freshly-arrived analysis without a full #gr-view re-render.
+{% endcomment %}<div id="gr-evalfill"{% if oob %} hx-swap-oob="true"{% endif %} class="evalbar__fill" style="height:{{ eval_fill }}%"></div>

--- a/chessdotcom_ai_coach/templates/partials/coach_card.html
+++ b/chessdotcom_ai_coach/templates/partials/coach_card.html
@@ -1,8 +1,11 @@
 {% comment %}
   The coach-card body (inside #gr-coach). Driven by `coach.mode`; also returned on
   its own by the analyze endpoint, so the pending states self-poll via htmx until
-  the background analysis is done.
+  the background analysis is done. When rendered standalone (`oob`), it also carries
+  the eval bar and board arrows out-of-band so a freshly-arrived analysis updates
+  the board without a full #gr-view re-render.
 {% endcomment %}
+{% if oob %}{% include "partials/_evalfill.html" %}{% include "partials/_arrows_svg.html" %}{% endif %}
 {% if coach.mode == "start" %}
 <div class="coach__placeholder">
   <span class="gr-glyph">&#9818;</span>

--- a/chessdotcom_ai_coach/templates/partials/position.html
+++ b/chessdotcom_ai_coach/templates/partials/position.html
@@ -29,23 +29,13 @@
 
       <div class="board-stage">
         <div class="evalbar{% if flipped %} evalbar--flipped{% endif %}">
-          <div class="evalbar__fill" style="height:{{ eval_fill }}%"></div>
+          {% include "partials/_evalfill.html" %}
           <div class="evalbar__mid"></div>
         </div>
         <div class="board-stage__board">
           <div class="gr-board-wrap">
             {% include "partials/board.html" with cells=cells board_class="board--lg" %}
-            {% if arrows %}
-            <svg class="gr-arrows" xmlns="http://www.w3.org/2000/svg">
-              <defs>
-                <marker id="gr-ah-brass" markerWidth="4" markerHeight="4" refX="2.4" refY="2" orient="auto"><path d="M0,0 L4,2 L0,4 z" fill="#b78e54"></path></marker>
-                <marker id="gr-ah-green" markerWidth="4" markerHeight="4" refX="2.4" refY="2" orient="auto"><path d="M0,0 L4,2 L0,4 z" fill="#4a7a52"></path></marker>
-              </defs>
-              {% for a in arrows %}
-              <line x1="{{ a.x1 }}%" y1="{{ a.y1 }}%" x2="{{ a.x2 }}%" y2="{{ a.y2 }}%" stroke="{{ a.color }}" stroke-width="7" stroke-linecap="round" opacity="0.92" marker-end="{{ a.marker }}"></line>
-              {% endfor %}
-            </svg>
-            {% endif %}
+            {% include "partials/_arrows_svg.html" %}
           </div>
         </div>
       </div>

--- a/chessdotcom_ai_coach/views.py
+++ b/chessdotcom_ai_coach/views.py
@@ -359,6 +359,9 @@ def analyze_position(request, id):
                 analyze_game_task.delay(request.user.id, id, fen, game.pgn or None)
             context = _position_context(request.user, game, sel)
 
+    # Standalone card render: carry the eval bar and board arrows out-of-band so
+    # a freshly-arrived analysis updates the board without a full #gr-view swap.
+    context["oob"] = True
     return render(request, "partials/coach_card.html", context)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chessdotcom-ai-coach"
-version = "1.5.1"
+version = "1.5.2"
 description = ""
 authors = [
     { name = "gab-25", email = "gabrielesorci.25@gmail.com" }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -159,6 +159,20 @@ class TestGameDetail:
         assert b'id="gr-view"' in response.content
         assert b"Reviewing" in response.content
 
+    def test_full_render_has_no_out_of_band_swaps(self, auth_client, user):
+        _make_game(user, is_active=False)
+
+        response = auth_client.get("/game/944768131/view", {"sel": "3"})
+        body = response.content.decode()
+
+        # The arrow overlay and eval bar are always present as stable OOB
+        # targets, but in a full #gr-view render they are inline — not
+        # out-of-band (that is only for the standalone coach-card self-poll).
+        assert 'id="gr-arrows"' in body
+        assert 'id="gr-evalfill"' in body
+        assert 'id="gr-arrows" hx-swap-oob' not in body
+        assert 'id="gr-evalfill" hx-swap-oob' not in body
+
     def test_embeds_completed_analysis(self, auth_client, user):
         _make_game(user, is_active=False)
         move_fen = board_utils.moves_from_pgn(PGN)[2]["fen_before"]
@@ -245,6 +259,32 @@ class TestAnalyzePosition:
         assert b"BEST MOVE" in response.content
         assert b"Develop the knight." in response.content
         mock_task.delay.assert_not_called()
+
+    def test_get_syncs_board_out_of_band(self, mock_task, auth_client, user):
+        _make_game(user)  # live, White (user) to move at the head (sel == head == 4)
+        CoachSuggestion.objects.create(
+            user=user,
+            game_id="944768131",
+            fen=FEN_LIVE,
+            status=CoachSuggestion.Status.DONE,
+            eval_text="+0.4",
+            eval_cp=0.4,
+            best_move_san="Bb5",
+            best_move_uci="f1b5",
+            analysis="Pin the knight.",
+        )
+
+        response = auth_client.get("/game/944768131/analyze", {"sel": "4"})
+        body = response.content.decode()
+
+        # The card body updated…
+        assert "BEST MOVE" in body
+        # …and the board arrows + eval bar ride along out-of-band so the board
+        # updates without a full #gr-view re-render.
+        assert 'id="gr-arrows"' in body
+        assert 'id="gr-evalfill"' in body
+        assert 'hx-swap-oob="true"' in body
+        assert 'stroke="#b78e54"' in body  # brass recommended-move arrow
 
     def test_analysis_never_calls_chess_com(self, mock_task, auth_client, user):
         _make_game(user, is_active=False)

--- a/theme/static/css/styles.css
+++ b/theme/static/css/styles.css
@@ -1027,8 +1027,8 @@ input {
   width: 15px;
   height: 15px;
   border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.4);
-  border-top-color: #fff;
+  border: 2px solid rgba(183, 142, 84, 0.25);
+  border-top-color: #b78e54;
   animation: spin 0.7s linear infinite;
 }
 @keyframes spin {

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "chessdotcom-ai-coach"
-version = "1.5.1"
+version = "1.5.2"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## What

While a position's analysis is in progress, the coach card self-polls `analyze_position` (GET) every 2s, swapping only `#gr-coach`. When the result arrived (`CoachSuggestion` → `DONE`), **only the card text** got updated: the recommended-move **arrow** and the **eval bar** — which live in `position.html`, not in the coach card — stayed stale until a full `#gr-view` re-render.

That re-render, on a **live** game at the user's turn, never happens until the opponent moves (`game_live` returns `204` when there's no new move); on a **finished** game reviewed afterwards it never happens until you navigate away and back. Result: the arrow and eval bar were out of sync with the suggestion just shown.

## How

- Extracted the `.evalbar__fill` and the board arrow SVG overlay into two shared partials (`partials/_evalfill.html`, `partials/_arrows_svg.html`) with stable ids (`gr-evalfill`, `gr-arrows`).
- The standalone coach-card render (`analyze_position` sets `oob=True`) now carries those two elements as **out-of-band swaps**, reusing the same pattern already used for the header pill in `position.html`. Full `#gr-view` renders keep them inline.
- The arrow overlay is now always rendered (even empty): it acts as a stable OOB target, and a result with no arrows clears stale ones. It's `pointer-events: none`, so it doesn't intercept board clicks.

## UI

- Recolored the waiting spinner from white to **brass** (`--brass`): on the cream coach-card placeholder — where the `pending`/`live_pending` states show it — the white spinner was practically invisible. `.spinner` is only used there, so the change is isolated.

## Tests

- `tests/test_views.py`: new test asserting that the GET on `analyze` (analyzed live position) carries the OOB `gr-arrows`/`gr-evalfill` elements with `hx-swap-oob` and the brass arrow; new test asserting that a full `#gr-view` render keeps those elements **inline** (no OOB).
- Full suite green: `106 passed`.
- Version bump: `1.5.1` → `1.5.2` (patch, consistent with the previous fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)