### PR TITLE
Show suggestion arrow for the player's just-played move at the live head

### DIFF
--- a/chessdotcom_ai_coach/views.py
+++ b/chessdotcom_ai_coach/views.py
@@ -111,11 +111,19 @@ def _position_context(user, game, sel):
     at_live_head = is_live and sel == head
     head_row = by_fen.get(game.fen)
     user_to_move = board_utils.active_color(game.fen) == orientation if game.fen else False
+    # At the live head, take over the display only when it's genuinely the
+    # player's decision point (your move) or there's no played user move to
+    # review. When the player has just moved and the opponent is on the clock,
+    # fall through to the review branch so the move keeps its arrows and coach
+    # comparison — matching how the same ply looks once the game is finished.
+    live_head_view = at_live_head and (
+        user_to_move or ply is None or ply["color"] != orientation
+    )
 
     coach = {"mode": "start"}
     arrows = []
 
-    if at_live_head:
+    if live_head_view:
         # The position you're about to play (or waiting on the opponent).
         if not user_to_move:
             coach = {"mode": "live_waiting"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chessdotcom-ai-coach"
-version = "1.5.2"
+version = "1.5.3"
 description = ""
 authors = [
     { name = "gab-25", email = "gabrielesorci.25@gmail.com" }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -465,6 +465,30 @@ class TestCoachCardModes:
         assert "Analysing the current position" in body
         assert 'hx-trigger="every 2s"' in body
 
+    def test_live_head_reviews_your_just_played_move(self, auth_client, user):
+        # Live game whose last ply is the user's OWN move (White Nf3), with the
+        # opponent now on the clock. The just-played move must still show its
+        # coach review and board arrows — not the bare "waiting" state.
+        live_pgn = '[Event "Test"]\n\n1. e4 e5 2. Nf3 *'
+        _make_game(
+            user,
+            pgn=live_pgn,
+            fen="rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+        )
+        # Suggestion for that move (position before White's 2. Nf3); best move
+        # differs from the played Nf3 → both recommended and played arrows.
+        fen_before = board_utils.moves_from_pgn(live_pgn)[2]["fen_before"]
+        _make_suggestion(
+            user, fen_before, best_move_san="d4", best_move_uci="d2d4"
+        )
+
+        response = auth_client.get("/game/944768131")
+        body = response.content.decode()
+
+        assert response.context["coach"]["mode"] == "analyzed"
+        assert 'stroke="#b78e54"' in body  # brass recommended arrow
+        assert 'stroke="#4a7a52"' in body  # green played-move arrow
+
 
 @pytest.mark.django_db
 class TestMovesGrid:

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "chessdotcom-ai-coach"
-version = "1.5.2"
+version = "1.5.3"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
On a live game sitting at the head ply, once the player has just moved the
position has the opponent to move, so the view took the at_live_head branch
and rendered "waiting for opponent" with no board arrows — even though the
moves grid and history still showed the move's suggestion. Narrow the
live-head takeover so a just-played user move falls through to the normal
review branch, drawing its recommended/played arrows and coach comparison,
matching how the same ply looks once the game is finished.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N431B9GGjHxTSs5AjC2QU8