### PR TITLE
Update analysis history and moves grid when a suggestion arrives

### DIFF
--- a/chessdotcom_ai_coach/templates/partials/coach_card.html
+++ b/chessdotcom_ai_coach/templates/partials/coach_card.html
@@ -2,10 +2,11 @@
   The coach-card body (inside #gr-coach). Driven by `coach.mode`; also returned on
   its own by the analyze endpoint, so the pending states self-poll via htmx until
   the background analysis is done. When rendered standalone (`oob`), it also carries
-  the eval bar and board arrows out-of-band so a freshly-arrived analysis updates
-  the board without a full #gr-view re-render.
+  the eval bar, the board arrows, the analysis-history timeline and the moves grid
+  out-of-band, so a freshly-arrived analysis updates the board, gets its history
+  slot and badges the move without a full #gr-view re-render.
 {% endcomment %}
-{% if oob %}{% include "partials/_evalfill.html" %}{% include "partials/_arrows_svg.html" %}{% endif %}
+{% if oob %}{% include "partials/_evalfill.html" %}{% include "partials/_arrows_svg.html" %}{% include "partials/history_list.html" %}{% include "partials/moves_grid.html" %}{% endif %}
 {% if coach.mode == "start" %}
 <div class="coach__placeholder">
   <span class="gr-glyph">&#9818;</span>

--- a/chessdotcom_ai_coach/templates/partials/history_list.html
+++ b/chessdotcom_ai_coach/templates/partials/history_list.html
@@ -1,7 +1,11 @@
 {% comment %}
   Analysis-history timeline (one entry per analysed user move). Click to jump to
-  that move. Expects `history`, `history_count`, `id`.
+  that move. Expects `history`, `history_count`, `id`. position.html renders it
+  inline; the coach-card self-poll renders it standalone with an out-of-band swap
+  (`oob`), so a freshly-arrived analysis gets its slot without a full #gr-view
+  re-render.
 {% endcomment %}
+<div id="gr-history"{% if oob %} hx-swap-oob="true"{% endif %}>
 <div class="gr-card">
   <div class="gr-card__head">
     <i class="fa-solid fa-clock-rotate-left"></i> Analysis history
@@ -21,4 +25,5 @@
     </li>
     {% endfor %}
   </ul>
+</div>
 </div>

--- a/chessdotcom_ai_coach/templates/partials/moves_grid.html
+++ b/chessdotcom_ai_coach/templates/partials/moves_grid.html
@@ -1,7 +1,12 @@
 {% comment %}
   Played-move grid; click a move to review it. Each item is an htmx GET that swaps
-  the whole position view. Expects `moves` (from _position_context) and `id`.
+  the whole position view. Expects `moves` (from _position_context) and `id`. The
+  outer container is always rendered (even with no moves) so its id is a stable
+  target: position.html renders it inline; the coach-card self-poll renders it
+  standalone with an out-of-band swap (`oob`), so a freshly-arrived analysis
+  updates the move's badge without a full #gr-view re-render.
 {% endcomment %}
+<div id="gr-moves-panel"{% if oob %} hx-swap-oob="true"{% endif %}>
 {% if moves %}
 <div class="moves gr-moves">
   <div class="moves__head"><i class="fa-solid fa-list-ol"></i> Moves · click to review</div>
@@ -21,3 +26,4 @@
   </ol>
 </div>
 {% endif %}
+</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chessdotcom-ai-coach"
-version = "1.6.0"
+version = "1.6.1"
 description = ""
 authors = [
     { name = "gab-25", email = "gabrielesorci.25@gmail.com" }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -187,13 +187,18 @@ class TestGameDetail:
         response = auth_client.get("/game/944768131/view", {"sel": "3"})
         body = response.content.decode()
 
-        # The arrow overlay and eval bar are always present as stable OOB
-        # targets, but in a full #gr-view render they are inline — not
-        # out-of-band (that is only for the standalone coach-card self-poll).
+        # The arrow overlay, eval bar, analysis history and moves grid are always
+        # present as stable OOB targets, but in a full #gr-view render they are
+        # inline — not out-of-band (that is only for the standalone coach-card
+        # self-poll).
         assert 'id="gr-arrows"' in body
         assert 'id="gr-evalfill"' in body
+        assert 'id="gr-history"' in body
+        assert 'id="gr-moves-panel"' in body
         assert 'id="gr-arrows" hx-swap-oob' not in body
         assert 'id="gr-evalfill" hx-swap-oob' not in body
+        assert 'id="gr-history" hx-swap-oob' not in body
+        assert 'id="gr-moves-panel" hx-swap-oob' not in body
 
     def test_embeds_completed_analysis(self, auth_client, user):
         _make_game(user, is_active=False)
@@ -307,6 +312,38 @@ class TestAnalyzePosition:
         assert 'id="gr-evalfill"' in body
         assert 'hx-swap-oob="true"' in body
         assert 'stroke="#b78e54"' in body  # brass recommended-move arrow
+
+    def test_get_adds_the_history_slot_out_of_band(self, mock_task, auth_client, user):
+        _make_game(user, is_active=False)
+        # sel 3 is White's 2nd move (Nf3) — the coach recommended it too.
+        _make_suggestion(user, _ply_fen(2))
+
+        response = auth_client.get("/game/944768131/analyze", {"sel": "3"})
+        body = response.content.decode()
+
+        # The freshly-arrived analysis gets its slot in the timeline and badges
+        # the move in the grid, both out-of-band — no full #gr-view re-render.
+        assert 'id="gr-history" hx-swap-oob="true"' in body
+        assert "Analysis history" in body
+        assert "Develop the knight." in body
+        assert 'class="gr-card__count">1<' in body
+        assert 'id="gr-moves-panel" hx-swap-oob="true"' in body
+        assert "gr-badge--followed" in body
+
+    def test_post_badges_the_move_as_pending_out_of_band(
+        self, mock_task, auth_client, user
+    ):
+        _make_game(user, is_active=False)
+
+        response = auth_client.post("/game/944768131/analyze", {"sel": "3"})
+        body = response.content.decode()
+
+        # Enqueueing marks the move pending in the grid straight away; nothing
+        # is done yet, so the history stays empty.
+        assert 'id="gr-moves-panel" hx-swap-oob="true"' in body
+        assert "gr-badge--pending" in body
+        assert 'id="gr-history" hx-swap-oob="true"' in body
+        assert 'class="gr-card__count">0<' in body
 
     def test_analysis_never_calls_chess_com(self, mock_task, auth_client, user):
         _make_game(user, is_active=False)

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "chessdotcom-ai-coach"
-version = "1.6.0"
+version = "1.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
The pending coach card self-polls analyze_position and swaps only #gr-coach,
carrying the eval bar and board arrows out-of-band. The analysis-history
timeline and the moves grid live inside #gr-view, so a freshly-arrived
suggestion got no history slot and the move kept no badge until a full
#gr-view re-render — which on a finished game, or a live game at your own
turn, may never happen.

Give both panels a stable id wrapper (gr-history, gr-moves-panel) with the
same conditional hx-swap-oob used by _evalfill/_arrows_svg, and include them
in the standalone coach-card render. The moves wrapper sits outside the
`if moves` guard so the target exists even with no moves. The data was
already in _position_context, so views.py is unchanged; enqueueing now also
badges the move as pending straight away.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016fmRcnvgK2czGHGCZLBDEd