### PR TITLE
Move the version from a floating badge into a real page footer

### DIFF
--- a/chessdotcom_ai_coach/templates/base.html
+++ b/chessdotcom_ai_coach/templates/base.html
@@ -51,10 +51,12 @@
     </header>
     {% endblock %}
 
-    {% block content %}{% endblock %}
+    <main class="app-main">{% block content %}{% endblock %}</main>
 
     {% block footer %}
-    <footer class="app-footer">v{{ version }}</footer>
+    <footer class="app-footer">
+      <div class="app-footer__inner">v{{ version }}</div>
+    </footer>
     {% endblock %}
   </body>
 </html>

--- a/chessdotcom_ai_coach/templates/login.html
+++ b/chessdotcom_ai_coach/templates/login.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% block title %}Sign in · Chessdotcom AI Coach{% endblock %}
 
-{% comment %} Login is a full-screen split panel — no app header. {% endcomment %}
+{% comment %} Login is a full-screen split panel — no app header, no footer. {% endcomment %}
 {% block header %}{% endblock %}
+{% block footer %}{% endblock %}
 
 {% block content %}
 <div class="login">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chessdotcom-ai-coach"
-version = "1.6.1"
+version = "1.6.2"
 description = ""
 authors = [
     { name = "gab-25", email = "gabrielesorci.25@gmail.com" }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -8,6 +8,7 @@ just seed the DB. The Celery task is mocked where analysis is enqueued.
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
 
 from chessdotcom_ai_coach.models import CoachSuggestion, Game
 from chessdotcom_ai_coach.services import board as board_utils
@@ -735,3 +736,19 @@ class TestEvalBar:
 
         assert response.context["eval_fill"] == 7
         assert b"height:7%" in response.content
+
+
+@pytest.mark.django_db
+class TestVersionFooter:
+    def test_footer_shows_version(self, auth_client, user):
+        _make_game(user)
+
+        response = auth_client.get("/")
+
+        assert b'class="app-footer"' in response.content
+        assert f"v{settings.APP_VERSION}".encode() in response.content
+
+    def test_login_page_has_no_footer(self, client):
+        response = client.get("/login")
+
+        assert b"app-footer" not in response.content

--- a/theme/static/css/styles.css
+++ b/theme/static/css/styles.css
@@ -63,10 +63,17 @@ body {
 
 body {
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   font-family: var(--font-body);
   color: var(--ink);
   background: var(--bg);
   -webkit-font-smoothing: antialiased;
+}
+
+/* Grows to push the footer to the bottom on short pages. */
+.app-main {
+  flex: 1 0 auto;
 }
 
 a {
@@ -199,21 +206,21 @@ input {
   background: #e8635a;
 }
 
-/* ===================== App footer (fixed version badge) =============== */
+/* ===================== App footer (version bar) ====================== */
 .app-footer {
-  position: fixed;
-  bottom: 10px;
-  right: 14px;
-  z-index: 5;
+  border-top: 1px solid var(--line);
+  background: var(--paper);
+}
+.app-footer__inner {
+  max-width: 1300px;
+  margin: 0 auto;
+  padding: 14px 28px;
+  display: flex;
+  justify-content: flex-end;
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.04em;
   color: var(--ink-faint);
-  background: var(--paper);
-  border: 1px solid var(--line);
-  border-radius: 20px;
-  padding: 3px 9px;
-  pointer-events: none;
   user-select: none;
 }
 
@@ -254,11 +261,11 @@ input {
 .page {
   max-width: 1240px;
   margin: 0 auto;
-  padding: 38px 28px 90px;
+  padding: 38px 28px 48px;
 }
 .page--wide {
   max-width: 1300px;
-  padding: 28px 28px 90px;
+  padding: 28px 28px 48px;
 }
 
 /* ===================== Buttons ===================== */
@@ -1607,7 +1614,10 @@ input {
     display: none;
   }
   .page {
-    padding: 26px 16px 80px;
+    padding: 26px 16px 40px;
+  }
+  .app-footer__inner {
+    padding: 12px 16px;
   }
   .coach__move {
     font-size: 44px;

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "chessdotcom-ai-coach"
-version = "1.6.1"
+version = "1.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
The version was already inside a <footer>, but the CSS turned it into a
position:fixed badge pinned to the bottom-right corner, overlapping the
board and cards. .page carried a 90px bottom padding just to keep content
clear of it.

Make it a real footer instead: a full-width bar in the document flow with
a top border and the version right-aligned inside a 1300px wrapper that
matches the header. The body becomes a flex column and the new
<main class="app-main"> grows, so the footer stays at the bottom of the
viewport on short pages too. The bottom padding hack on .page/.page--wide
is reduced accordingly.

The login page overrides {% block footer %} the same way it already
overrides the header, keeping the split panel full-screen.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RdyNyGonHLD1JiuLerSL8n