### PR TITLE
Move the version from the page footer into a header badge

### DIFF
--- a/chessdotcom_ai_coach/templates/base.html
+++ b/chessdotcom_ai_coach/templates/base.html
@@ -30,6 +30,7 @@
           <span>
             <span class="brand__name">Chessdotcom</span><br />
             <span class="brand__sub">AI&nbsp;COACH</span>
+            <span class="brand__version">v{{ version }}</span>
           </span>
         </a>
 
@@ -52,11 +53,5 @@
     {% endblock %}
 
     <main class="app-main">{% block content %}{% endblock %}</main>
-
-    {% block footer %}
-    <footer class="app-footer">
-      <div class="app-footer__inner">v{{ version }}</div>
-    </footer>
-    {% endblock %}
   </body>
 </html>

--- a/chessdotcom_ai_coach/templates/login.html
+++ b/chessdotcom_ai_coach/templates/login.html
@@ -1,9 +1,8 @@
 {% extends "base.html" %}
 {% block title %}Sign in · Chessdotcom AI Coach{% endblock %}
 
-{% comment %} Login is a full-screen split panel — no app header, no footer. {% endcomment %}
+{% comment %} Login is a full-screen split panel — no app header. {% endcomment %}
 {% block header %}{% endblock %}
-{% block footer %}{% endblock %}
 
 {% block content %}
 <div class="login">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chessdotcom-ai-coach"
-version = "1.6.2"
+version = "1.6.3"
 description = ""
 authors = [
     { name = "gab-25", email = "gabrielesorci.25@gmail.com" }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -739,16 +739,16 @@ class TestEvalBar:
 
 
 @pytest.mark.django_db
-class TestVersionFooter:
-    def test_footer_shows_version(self, auth_client, user):
+class TestVersionBadge:
+    def test_header_shows_version(self, auth_client, user):
         _make_game(user)
 
         response = auth_client.get("/")
 
-        assert b'class="app-footer"' in response.content
+        assert b'class="brand__version"' in response.content
         assert f"v{settings.APP_VERSION}".encode() in response.content
 
-    def test_login_page_has_no_footer(self, client):
+    def test_login_page_has_no_version(self, client):
         response = client.get("/login")
 
-        assert b"app-footer" not in response.content
+        assert b"brand__version" not in response.content

--- a/theme/static/css/styles.css
+++ b/theme/static/css/styles.css
@@ -157,6 +157,17 @@ input {
   color: var(--brass);
   line-height: 1.3;
 }
+.brand__version {
+  margin-left: 8px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  color: var(--chrome-ink-dim);
+  border: 1px solid var(--chrome-line);
+  border-radius: 4px;
+  padding: 1px 5px;
+  user-select: none;
+}
 
 .back-link {
   margin-left: 6px;
@@ -204,24 +215,6 @@ input {
 }
 .status-pill--watch .status-pill__dot {
   background: #e8635a;
-}
-
-/* ===================== App footer (version bar) ====================== */
-.app-footer {
-  border-top: 1px solid var(--line);
-  background: var(--paper);
-}
-.app-footer__inner {
-  max-width: 1300px;
-  margin: 0 auto;
-  padding: 14px 28px;
-  display: flex;
-  justify-content: flex-end;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.04em;
-  color: var(--ink-faint);
-  user-select: none;
 }
 
 .user-chip {
@@ -1610,14 +1603,16 @@ input {
     padding: 0 16px;
     gap: 12px;
   }
+  .brand__version {
+    margin-left: 6px;
+    border: none;
+    padding: 0;
+  }
   .user-chip__name {
     display: none;
   }
   .page {
     padding: 26px 16px 40px;
-  }
-  .app-footer__inner {
-    padding: 12px 16px;
   }
   .coach__move {
     font-size: 44px;

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "chessdotcom-ai-coach"
-version = "1.6.2"
+version = "1.6.3"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Context

PR #39 moved the version out of a floating badge and into a real page footer. That footer's only content is the version string, so every page carries a full-width bar for a 10px value — disproportionate, and visually detached from the rest of the UI. This moves it into the header instead and drops the footer entirely.

Note this is **not** a revert of #39: the old placement was a floating overlay, this one is an inline badge inside the sticky header.

## Changes

- `templates/base.html` — the version renders as `<span class="brand__version">` next to the `AI COACH` brand sub-line; the `{% block footer %}` and its `<footer>` are removed.
- `templates/login.html` — drops the now-nonexistent `{% block footer %}` override. Login still shows no version, since it already blanks `{% block header %}` and has its own `login__brand` markup.
- `theme/static/css/styles.css` — new `.brand__version` rule reusing the header's existing custom properties (`--font-mono`, `--chrome-ink-dim`, `--chrome-line`); `.app-footer` / `.app-footer__inner` removed. Below 640px the badge drops its border and padding so the header stays on one line.
- `tests/test_views.py` — `TestVersionFooter` → `TestVersionBadge`, assertions now target `brand__version`.
- Version bumped `1.6.2` → `1.6.3`.

`{{ version }}` is already a global template variable from the `app_version` context processor, so no view, settings or context-processor change was needed.

## Verification

- Full suite: **139 passed**.
- `grep` for `app-footer|block footer` outside `staticfiles/`: zero occurrences.
- Rendered `base.html` inspected — badge sits inside `.brand`, on the `AI COACH` line.
- `body` is a flex column with `min-height: 100vh` and `.app-main` has `flex: 1 0 auto`, so removing the footer leaves no gap.

Not verified: no headless browser is available in the dev environment, so the badge has not been visually checked in a real render. Worth eyeballing its baseline alignment against `AI COACH`, and that it doesn't crowd the `status-pill` on the home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)