### PR TITLE
Show the move you're about to play as a live slot in the moves grid

### DIFF
--- a/chessdotcom_ai_coach/templates/partials/moves_grid.html
+++ b/chessdotcom_ai_coach/templates/partials/moves_grid.html
@@ -1,13 +1,15 @@
 {% comment %}
   Played-move grid; click a move to review it. Each item is an htmx GET that swaps
-  the whole position view. Expects `moves` (from _position_context) and `id`. The
-  outer container is always rendered (even with no moves) so its id is a stable
-  target: position.html renders it inline; the coach-card self-poll renders it
-  standalone with an out-of-band swap (`oob`), so a freshly-arrived analysis
-  updates the move's badge without a full #gr-view re-render.
+  the whole position view. Expects `moves` and `live_move` (from _position_context)
+  and `id`. `live_move` is the provisional slot for the move you're about to play on
+  a live game: it carries the coach's pending/recommended state before any ply
+  exists to badge. The outer container is always rendered (even with no moves) so
+  its id is a stable target: position.html renders it inline; the coach-card
+  self-poll renders it standalone with an out-of-band swap (`oob`), so a
+  freshly-arrived analysis updates the badge without a full #gr-view re-render.
 {% endcomment %}
 <div id="gr-moves-panel"{% if oob %} hx-swap-oob="true"{% endif %}>
-{% if moves %}
+{% if moves or live_move %}
 <div class="moves gr-moves">
   <div class="moves__head"><i class="fa-solid fa-list-ol"></i> Moves · click to review</div>
   <ol class="gr-moves-grid">
@@ -23,6 +25,18 @@
       {% endif %}
     </li>
     {% endfor %}
+    {% if live_move %}
+    <li class="gr-move gr-move--live{% if live_move.selected %} gr-move--sel{% endif %}"
+        hx-get="{% url 'game_position' id %}?sel={{ live_move.sel }}" hx-target="#gr-view" hx-swap="outerHTML">
+      <span class="gr-move__no">{{ live_move.no }}{% if live_move.color == 'white' %}.{% else %}…{% endif %}</span>
+      <span class="gr-move__san gr-move__san--live">your move</span>
+      {% if live_move.rec_san %}
+      <span class="gr-badge gr-badge--live">&#9818; {{ live_move.rec_san }}</span>
+      {% elif live_move.pending %}
+      <span class="gr-badge gr-badge--pending">…</span>
+      {% endif %}
+    </li>
+    {% endif %}
   </ol>
 </div>
 {% endif %}

--- a/chessdotcom_ai_coach/templates/partials/position.html
+++ b/chessdotcom_ai_coach/templates/partials/position.html
@@ -49,17 +49,17 @@
       <div class="movebar">
         <span class="movebar__last">Last: {{ last_move|default:"—" }}</span>
         <div class="gr-navwrap">
-          {% if is_live and sel < head %}
+          {% if is_live and sel < live_sel %}
           <button type="button" class="gr-live-btn" title="Jump to the live position"
-                  hx-get="{% url 'game_position' id %}?sel={{ head }}" hx-target="#gr-view" hx-swap="outerHTML">
-            <span class="status-pill__dot"></span>{{ behind }} new · live
+                  hx-get="{% url 'game_position' id %}?sel={{ live_sel }}" hx-target="#gr-view" hx-swap="outerHTML">
+            <span class="status-pill__dot"></span>{% if behind %}{{ behind }} new · {% endif %}live
           </button>
           {% endif %}
           <div class="gr-nav">
             <button type="button" title="Start" hx-get="{% url 'game_position' id %}?sel=0" hx-target="#gr-view" hx-swap="outerHTML" hx-trigger="click, keydown[key=='Home'] from:body">«</button>
             <button type="button" title="Back (←)" hx-get="{% url 'game_position' id %}?sel={{ prev_sel }}" hx-target="#gr-view" hx-swap="outerHTML" hx-trigger="click, keydown[key=='ArrowLeft'] from:body">‹</button>
             <button type="button" title="Forward (→)" hx-get="{% url 'game_position' id %}?sel={{ next_sel }}" hx-target="#gr-view" hx-swap="outerHTML" hx-trigger="click, keydown[key=='ArrowRight'] from:body">›</button>
-            <button type="button" title="End" hx-get="{% url 'game_position' id %}?sel={{ head }}" hx-target="#gr-view" hx-swap="outerHTML" hx-trigger="click, keydown[key=='End'] from:body">»</button>
+            <button type="button" title="End" hx-get="{% url 'game_position' id %}?sel={{ live_sel }}" hx-target="#gr-view" hx-swap="outerHTML" hx-trigger="click, keydown[key=='End'] from:body">»</button>
           </div>
         </div>
       </div>

--- a/chessdotcom_ai_coach/views.py
+++ b/chessdotcom_ai_coach/views.py
@@ -77,7 +77,8 @@ def _position_context(user, game, sel):
     scheduler) and the persisted ``CoachSuggestion`` rows — no Chess.com call —
     so navigation, the live poll and the review of a finished game are all cheap
     DB reads. ``sel`` is the 0-based ply cursor (0 = starting position, ``head``
-    = the latest/current position).
+    = the last played ply, ``live_sel`` = the end of the timeline — the live
+    "your move" slot when it's your turn, ``head`` otherwise).
     """
     username = user.chess_username
     orientation = "white" if (game.white_name or "").lower() == username.lower() else "black"
@@ -91,26 +92,33 @@ def _position_context(user, game, sel):
     by_fen = {row.fen: row for row in history}
 
     head = len(moves)
-    sel = max(0, min(head, sel))
     is_live = game.is_active
-    ply = moves[sel - 1] if sel > 0 else None
+    head_row = by_fen.get(game.fen)
+    user_to_move = board_utils.active_color(game.fen) == orientation if game.fen else False
+    # The move you're about to play gets its own cursor one past the last played
+    # ply, so the opponent's final move stays reviewable at `head`. `live_sel` is
+    # therefore the end of the timeline; `head` stays the PGN ply count (what the
+    # live poll compares against).
+    has_live_slot = is_live and user_to_move
+    live_sel = head + 1 if has_live_slot else head
+    sel = max(0, min(live_sel, sel))
+    ply_idx = min(sel, head)  # the live slot sits on the board of the last ply
+    ply = moves[ply_idx - 1] if ply_idx > 0 else None
 
     # Board + last-move highlight for the selected ply.
-    board_fen = positions[sel] if sel < len(positions) else (game.fen or _START_FEN)
+    board_fen = positions[ply_idx] if ply_idx < len(positions) else (game.fen or _START_FEN)
     highlight = _uci_to_squares(ply["uci"]) if ply else []
     cells = board_utils.fen_to_cells(board_fen, highlight=highlight, flipped=flipped)
 
     # Eval bar: carry the last analysed value forward across un-analysed plies.
     eval_fill = 50
-    for i in range(1, sel + 1):
+    for i in range(1, ply_idx + 1):
         m = moves[i - 1]
         s = m["suggestion"]
         if m["color"] == orientation and s is not None and s.status == CoachSuggestion.Status.DONE:
             eval_fill = _eval_fill(s.eval_cp)
 
-    at_live_head = is_live and sel == head
-    head_row = by_fen.get(game.fen)
-    user_to_move = board_utils.active_color(game.fen) == orientation if game.fen else False
+    at_live_head = is_live and sel == live_sel
     # At the live head, take over the display only when it's genuinely the
     # player's decision point (your move) or there's no played user move to
     # review. When the player has just moved and the opponent is on the clock,
@@ -188,22 +196,19 @@ def _position_context(user, game, sel):
 
     # Live "your move" slot: at the head of a live game, while it's your turn, the
     # coach's suggestion has no played ply to badge yet. Give it a provisional item
-    # at the end of the grid so the pending state and the recommendation are visible
-    # before you move. It shares the `head` cursor with the last played ply, so when
-    # it owns the selection the real item must give it up.
+    # at the end of the grid, on its own `live_sel` cursor, so the pending state and
+    # the recommendation are visible before you move.
     live_move = None
-    if is_live and user_to_move:
+    if has_live_slot:
         done = head_row is not None and head_row.status == CoachSuggestion.Status.DONE
         live_move = {
-            "sel": head,
+            "sel": live_sel,
             "no": board_utils.fullmove_number(game.fen),
             "color": orientation,
             "pending": head_row is not None and head_row.status == CoachSuggestion.Status.PENDING,
             "rec_san": (head_row.best_move_san if done else "") or "",
             "selected": at_live_head,
         }
-        if live_move["selected"] and moves_view:
-            moves_view[-1]["selected"] = False
 
     # Analysis-history timeline (analysed user moves, in order).
     history_view = []
@@ -244,9 +249,10 @@ def _position_context(user, game, sel):
         "is_live": is_live,
         "sel": sel,
         "head": head,
-        "behind": head - sel,
+        "live_sel": live_sel,
+        "behind": max(0, head - sel),
         "prev_sel": max(0, sel - 1),
-        "next_sel": min(head, sel + 1),
+        "next_sel": min(live_sel, sel + 1),
         "orientation": orientation,
         "flipped": flipped,
         "white_name": game.white_name or "White",
@@ -305,7 +311,8 @@ def game_detail(request, id):
         return render(request, "error.html", {"message": "Game not found."}, status=404)
 
     moves = board_utils.moves_from_pgn(game.pgn)
-    sel = len(moves) if game.is_active else 0
+    # +1 lands on the live "your move" slot when it's your turn; clamped otherwise.
+    sel = len(moves) + 1 if game.is_active else 0
     context = _position_context(request.user, game, sel)
     return render(request, "game_detail.html", context)
 
@@ -340,7 +347,9 @@ def game_live(request, id):
         return HttpResponse(status=204)  # no new move — keep polling
 
     following = sel >= known_head
-    render_sel = head if following else sel
+    # Following the head means following the live slot too (clamped when the
+    # opponent is the one on the clock).
+    render_sel = head + 1 if following else sel
     return render(request, "partials/position.html", _position_context(request.user, game, render_sel))
 
 

--- a/chessdotcom_ai_coach/views.py
+++ b/chessdotcom_ai_coach/views.py
@@ -186,6 +186,25 @@ def _position_context(user, game, sel):
             }
         )
 
+    # Live "your move" slot: at the head of a live game, while it's your turn, the
+    # coach's suggestion has no played ply to badge yet. Give it a provisional item
+    # at the end of the grid so the pending state and the recommendation are visible
+    # before you move. It shares the `head` cursor with the last played ply, so when
+    # it owns the selection the real item must give it up.
+    live_move = None
+    if is_live and user_to_move:
+        done = head_row is not None and head_row.status == CoachSuggestion.Status.DONE
+        live_move = {
+            "sel": head,
+            "no": board_utils.fullmove_number(game.fen),
+            "color": orientation,
+            "pending": head_row is not None and head_row.status == CoachSuggestion.Status.PENDING,
+            "rec_san": (head_row.best_move_san if done else "") or "",
+            "selected": at_live_head,
+        }
+        if live_move["selected"] and moves_view:
+            moves_view[-1]["selected"] = False
+
     # Analysis-history timeline (analysed user moves, in order).
     history_view = []
     for i, m in enumerate(moves, start=1):
@@ -243,6 +262,7 @@ def _position_context(user, game, sel):
         "arrows": arrows,
         "coach": coach,
         "moves": moves_view,
+        "live_move": live_move,
         "history": history_view,
         "history_count": len(history_view),
         "last_move": last_move,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chessdotcom-ai-coach"
-version = "1.6.3"
+version = "1.6.4"
 description = ""
 authors = [
     { name = "gab-25", email = "gabrielesorci.25@gmail.com" }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -141,7 +141,9 @@ class TestGameDetail:
         assert response.status_code == 200
         assert b'id="gr-view"' in response.content
         assert b"WATCHING LIVE" in response.content
-        assert response.context["sel"] == response.context["head"] == 4
+        # Your turn: the page opens on the live slot, one past the last played ply.
+        assert response.context["head"] == 4
+        assert response.context["sel"] == response.context["live_sel"] == 5
         # At the live head, your move, no suggestion yet → request button.
         assert b"Request suggestion" in response.content
 
@@ -289,7 +291,7 @@ class TestAnalyzePosition:
         mock_task.delay.assert_not_called()
 
     def test_get_syncs_board_out_of_band(self, mock_task, auth_client, user):
-        _make_game(user)  # live, White (user) to move at the head (sel == head == 4)
+        _make_game(user)  # live, White (user) to move — the live slot is sel 5
         CoachSuggestion.objects.create(
             user=user,
             game_id="944768131",
@@ -302,7 +304,7 @@ class TestAnalyzePosition:
             analysis="Pin the knight.",
         )
 
-        response = auth_client.get("/game/944768131/analyze", {"sel": "4"})
+        response = auth_client.get("/game/944768131/analyze", {"sel": "5"})
         body = response.content.decode()
 
         # The card body updated…
@@ -566,12 +568,17 @@ class TestMovesGrid:
 
 @pytest.mark.django_db
 class TestLiveMoveSlot:
-    """The provisional grid item for the move you're about to play (live head)."""
+    """The provisional grid item for the move you're about to play.
+
+    On a live game where it's the user's turn the slot owns its own cursor,
+    ``live_sel`` (``head + 1`` — here 5), so the opponent's last move stays
+    reviewable at ``head``.
+    """
 
     def test_live_turn_shows_an_empty_slot(self, auth_client, user):
         _make_game(user)  # live, White (user) to move, no suggestion yet
 
-        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+        response = auth_client.get("/game/944768131/view", {"sel": "5"})
         body = response.content.decode()
 
         assert "gr-move--live" in body
@@ -584,7 +591,7 @@ class TestLiveMoveSlot:
         _make_game(user)
         _make_suggestion(user, FEN_LIVE, status=CoachSuggestion.Status.PENDING)
 
-        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+        response = auth_client.get("/game/944768131/view", {"sel": "5"})
         body = response.content.decode()
 
         assert "gr-move--live" in body
@@ -596,7 +603,7 @@ class TestLiveMoveSlot:
         _make_game(user)
         _make_suggestion(user, FEN_LIVE, best_move_san="Bb5")
 
-        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+        response = auth_client.get("/game/944768131/view", {"sel": "5"})
         body = response.content.decode()
 
         # The move isn't played yet — the grid still holds only the 4 PGN plies,
@@ -607,35 +614,58 @@ class TestLiveMoveSlot:
     def test_slot_owns_the_selection_at_the_live_head(self, auth_client, user):
         _make_game(user)
 
+        response = auth_client.get("/game/944768131/view", {"sel": "5"})
+        body = response.content.decode()
+
+        assert body.count("gr-move--sel") == 1
+        assert "gr-move--live gr-move--sel" in body
+
+    def test_opponents_last_move_stays_reviewable(self, auth_client, user):
+        _make_game(user)  # live, your turn — head 4 is Black's Nc6
+
         response = auth_client.get("/game/944768131/view", {"sel": "4"})
         body = response.content.decode()
 
-        # The last played ply and the slot share the `head` cursor — only one of
-        # them may light up.
+        # Stepping back from the live slot reviews the opponent's move rather
+        # than falling through to the live view.
+        assert response.context["coach"]["mode"] == "opponent"
+        assert "Reviewing: 2… Nc6" in body
+        # …and the selection is on that ply, not on the live slot.
         assert body.count("gr-move--sel") == 1
-        assert "gr-move--live gr-move--sel" in body
+        assert "gr-move--live gr-move--sel" not in body
+
+    def test_back_from_the_live_slot_lands_on_the_last_ply(self, auth_client, user):
+        _make_game(user)
+
+        response = auth_client.get("/game/944768131/view", {"sel": "5"})
+
+        assert response.context["prev_sel"] == 4
+        assert response.context["next_sel"] == 5
 
     def test_no_slot_while_the_opponent_is_on_the_clock(self, auth_client, user):
         # Black to move: the coach has nothing to suggest for the user yet.
         _make_game(user, fen=FEN_LIVE.replace(" w ", " b "))
 
-        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+        response = auth_client.get("/game/944768131/view", {"sel": "5"})
 
         assert b"gr-move--live" not in response.content
+        # The timeline ends at the last played ply.
+        assert response.context["sel"] == response.context["live_sel"] == 4
 
     def test_no_slot_on_a_finished_game(self, auth_client, user):
         _make_game(user, is_active=False)
 
-        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+        response = auth_client.get("/game/944768131/view", {"sel": "5"})
 
         assert b"gr-move--live" not in response.content
+        assert response.context["sel"] == 4
 
     def test_arriving_suggestion_updates_the_slot_out_of_band(self, auth_client, user):
         _make_game(user)
         _make_suggestion(user, FEN_LIVE, best_move_san="Bb5")
 
         # The `live_pending` self-poll lands on the analyze endpoint.
-        response = auth_client.get("/game/944768131/analyze", {"sel": "4"})
+        response = auth_client.get("/game/944768131/analyze", {"sel": "5"})
         body = response.content.decode()
 
         assert 'id="gr-moves-panel" hx-swap-oob="true"' in body

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -565,6 +565,86 @@ class TestMovesGrid:
 
 
 @pytest.mark.django_db
+class TestLiveMoveSlot:
+    """The provisional grid item for the move you're about to play (live head)."""
+
+    def test_live_turn_shows_an_empty_slot(self, auth_client, user):
+        _make_game(user)  # live, White (user) to move, no suggestion yet
+
+        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+        body = response.content.decode()
+
+        assert "gr-move--live" in body
+        assert "your move" in body
+        # Nothing requested yet — no badge on the slot.
+        assert "gr-badge--live" not in body
+        assert "gr-badge--pending" not in body
+
+    def test_pending_suggestion_badges_the_slot(self, auth_client, user):
+        _make_game(user)
+        _make_suggestion(user, FEN_LIVE, status=CoachSuggestion.Status.PENDING)
+
+        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+        body = response.content.decode()
+
+        assert "gr-move--live" in body
+        assert "gr-badge--pending" in body
+
+    def test_done_suggestion_shows_the_recommendation_before_you_play(
+        self, auth_client, user
+    ):
+        _make_game(user)
+        _make_suggestion(user, FEN_LIVE, best_move_san="Bb5")
+
+        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+        body = response.content.decode()
+
+        # The move isn't played yet — the grid still holds only the 4 PGN plies,
+        # but the coach's pick is already visible on the live slot.
+        assert "gr-badge--live" in body
+        assert "Bb5" in body
+
+    def test_slot_owns_the_selection_at_the_live_head(self, auth_client, user):
+        _make_game(user)
+
+        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+        body = response.content.decode()
+
+        # The last played ply and the slot share the `head` cursor — only one of
+        # them may light up.
+        assert body.count("gr-move--sel") == 1
+        assert "gr-move--live gr-move--sel" in body
+
+    def test_no_slot_while_the_opponent_is_on_the_clock(self, auth_client, user):
+        # Black to move: the coach has nothing to suggest for the user yet.
+        _make_game(user, fen=FEN_LIVE.replace(" w ", " b "))
+
+        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+
+        assert b"gr-move--live" not in response.content
+
+    def test_no_slot_on_a_finished_game(self, auth_client, user):
+        _make_game(user, is_active=False)
+
+        response = auth_client.get("/game/944768131/view", {"sel": "4"})
+
+        assert b"gr-move--live" not in response.content
+
+    def test_arriving_suggestion_updates_the_slot_out_of_band(self, auth_client, user):
+        _make_game(user)
+        _make_suggestion(user, FEN_LIVE, best_move_san="Bb5")
+
+        # The `live_pending` self-poll lands on the analyze endpoint.
+        response = auth_client.get("/game/944768131/analyze", {"sel": "4"})
+        body = response.content.decode()
+
+        assert 'id="gr-moves-panel" hx-swap-oob="true"' in body
+        assert "gr-move--live" in body
+        assert "gr-badge--live" in body
+        assert "Bb5" in body
+
+
+@pytest.mark.django_db
 class TestHistoryList:
     """partials/history_list.html — the analysed-moves timeline."""
 

--- a/theme/static/css/styles.css
+++ b/theme/static/css/styles.css
@@ -1546,6 +1546,11 @@ input {
   background: #f0e9d6;
   box-shadow: 0 0 0 2px rgba(183, 142, 84, 0.7);
 }
+/* The move you're about to play on a live game — provisional, not yet a ply. */
+.gr-move--live {
+  background: rgba(183, 142, 84, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(183, 142, 84, 0.45);
+}
 .gr-move__no {
   font-family: var(--font-mono);
   font-size: 12px;
@@ -1556,6 +1561,10 @@ input {
   font-family: var(--font-display);
   font-weight: 600;
   color: var(--ink);
+}
+.gr-move__san--live {
+  font-weight: 400;
+  color: var(--ink-mute);
 }
 .gr-badge {
   margin-left: auto;
@@ -1573,6 +1582,10 @@ input {
   background: rgba(74, 122, 82, 0.14);
 }
 .gr-badge--differed {
+  color: #8a6a2e;
+  background: rgba(183, 142, 84, 0.16);
+}
+.gr-badge--live {
   color: #8a6a2e;
   background: rgba(183, 142, 84, 0.16);
 }

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "chessdotcom-ai-coach"
-version = "1.6.3"
+version = "1.6.4"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Context

The moves grid is derived purely from the PGN: `moves_view` iterates `moves_from_pgn(pgn)` and a `CoachSuggestion` only *decorates* an existing ply via `annotate_moves` (joined on `(move_no, color)`).

So when a suggestion arrived for the **live head** — the move you are about to play (`coach.mode` `live_request` / `live_pending` / `live_analyzed`) — there was no played ply to attach it to and nothing showed up in the grid. The recommendation lived only in the coach card until you actually moved, at which point the 5s live poll re-rendered the view and the ply appeared already badged.

## Change

While a game is live and it's the user's turn, the grid gets a provisional item in its tail:

- `_position_context` builds `live_move` from the already-loaded `head_row` (no extra query): move number from the current FEN, plus the suggestion's pending / recommended state.
- The slot and the last played ply share the `head` cursor, so when the slot owns the selection the real item gives it up — otherwise both lit up.
- `moves_grid.html` renders it as `gr-move--live` with a muted "your move" label and either the `♔ <san>` badge or the pending `…`. The template guard became `{% if moves or live_move %}` so the slot also shows at move 1 with an empty PGN.
- The slot renders badge-less when no suggestion has been requested yet: it keeps the grid's tail stable instead of popping in and out, and stays clickable to jump to live.

No new wiring for the refresh path — `analyze_position` already carries the grid out-of-band, so the "Request suggestion" POST paints the slot as pending and the 2s self-poll flips it to the recommendation without a full `#gr-view` re-render. Once the move is played the live poll replaces the slot with the real badged ply, and the slot moves on to the next turn (or disappears while the opponent is on the clock).

## Tests

New `TestLiveMoveSlot`: empty slot on your turn, pending badge, recommendation visible before the move is played, single selection at the live head, no slot while the opponent is to move or on a finished game, and the out-of-band arrival path.

`uv run pytest -q` → 146 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)