### PR TITLE
Use PGN as authority for game position on home page

### DIFF
--- a/chessdotcom_ai_coach/services/board.py
+++ b/chessdotcom_ai_coach/services/board.py
@@ -10,7 +10,7 @@ game views.
 from __future__ import annotations
 
 import io
-import re
+from functools import lru_cache
 from typing import Dict, List, Optional
 
 import chess
@@ -98,48 +98,58 @@ def fullmove_number(fen: Optional[str]) -> Optional[int]:
     return None
 
 
-def last_move_from_pgn(pgn: Optional[str]) -> Optional[str]:
-    """Extract the last move played from a PGN, with its move number.
+_LAST_PLY_KEYS = ("move_no", "color", "san", "uci", "fen_after")
 
-    Returns something like ``"11...Be7"`` or ``"12. Nf5"``, or ``None`` when the
-    movetext can't be parsed.
+
+@lru_cache(maxsize=512)
+def _last_ply_tuple(pgn: str) -> Optional[tuple]:
+    """Replay ``pgn`` once and return its last ply plus the reached FEN, as a tuple.
+
+    Split out from :func:`last_ply_from_pgn` purely so the memoisation can hang off
+    an immutable value: a cached dict would be handed to callers free to mutate it,
+    poisoning every later cache hit. Keyed on the PGN text, which only changes when
+    a move is actually played — so the home page's 5s poll re-replays a game only
+    on the tick where it advanced.
+    """
+    try:
+        game = chess.pgn.read_game(io.StringIO(pgn))
+    except Exception:
+        return None
+    if game is None:
+        return None
+
+    board = game.board()
+    last: Optional[tuple] = None
+    for move in game.mainline_moves():
+        move_no = board.fullmove_number
+        color = "white" if board.turn == chess.WHITE else "black"
+        try:
+            san = board.san(move)
+            board.push(move)
+        except Exception:
+            break  # malformed movetext — stop at the last legal ply
+        last = (move_no, color, san, move.uci())
+    return last + (board.fen(),) if last else None
+
+
+def last_ply_from_pgn(pgn: Optional[str]) -> Optional[Dict]:
+    """The last played ply of a PGN, together with the position it reached.
+
+    Returns ``{move_no, color, san, uci, fen_after}`` — the same shape as an entry
+    of :func:`moves_from_pgn`, except the FEN is the position *after* the ply (hence
+    ``fen_after``): what the board actually shows now. ``move_no``/``color`` describe
+    the move that was *played*, so they are the counterpart of the side now *to
+    move* — derive the latter with :func:`fullmove_number` / :func:`active_color` on
+    ``fen_after`` rather than adjusting these by hand. Returns ``None`` when the PGN
+    is missing, unparseable or carries no moves.
+
+    Exists so a caller that only needs "where is this game now" replays the PGN once
+    instead of pairing :func:`moves_from_pgn` with :func:`positions_from_pgn`.
     """
     if not pgn:
         return None
-
-    # Drop the header tags; keep the movetext that follows the blank line.
-    movetext = pgn
-    if "\n\n" in pgn:
-        movetext = pgn.split("\n\n", 1)[1]
-
-    # Strip comments, NAGs, result markers and variation parens.
-    movetext = re.sub(r"\{[^}]*\}", " ", movetext)
-    movetext = re.sub(r"\$\d+", " ", movetext)
-    movetext = re.sub(r"[()]", " ", movetext)
-    movetext = re.sub(r"\b(1-0|0-1|1/2-1/2|\*)\b", " ", movetext)
-
-    # Tokens: a move number like "12." / "12..." or a SAN move.
-    tokens = movetext.split()
-    last_san = None
-    last_number = None
-    pending_black = False  # True once we've seen "N..." (black to move)
-    for tok in tokens:
-        m = re.fullmatch(r"(\d+)\.(\.\.)?", tok)
-        if m:
-            last_number = int(m.group(1))
-            pending_black = bool(m.group(2))
-            continue
-        # A SAN move (allow check/mate/promotion/castle marks).
-        if re.fullmatch(r"[NBRQKOa-h][A-Za-z0-9+#=\-]*", tok):
-            last_san = tok
-            if last_number is not None:
-                sep = "..." if pending_black else ". "
-                last_san_labeled = f"{last_number}{sep}{tok}"
-            else:
-                last_san_labeled = tok
-            # After a white move, the next SAN (same number) is black's.
-            pending_black = True
-    return last_san_labeled if last_san else None
+    found = _last_ply_tuple(pgn)
+    return dict(zip(_LAST_PLY_KEYS, found)) if found else None
 
 
 def moves_from_pgn(pgn: Optional[str]) -> List[Dict]:

--- a/chessdotcom_ai_coach/views.py
+++ b/chessdotcom_ai_coach/views.py
@@ -14,14 +14,25 @@ _START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 def _decorate_games(games, username):
     """Attach board cells, move number, side-to-move and turn ownership to `Game` rows.
 
-    Used for both the current and past-games sections of the home page (both
-    plain DB reads). `turn` reproduces the side-to-move from the stored FEN, and
+    Used for both the current and past-games sections of the home page (both plain
+    DB reads). The PGN — not the stored ``fen`` column — is the authority for what
+    is on the board, matching the detail page (see `_position_context`): Chess.com's
+    ``fen`` field can lag its own movetext, and is empty on some payloads, which
+    rendered the card as an untouched starting position (`board.fen_to_cells` falls
+    back to it silently). The stored FEN stays the fallback for rows snapshotted
+    without a PGN. `turn` reproduces the side-to-move from that position, and
     `is_user_turn` highlights games awaiting the logged-in user's move.
+
+    Note `move_no`/`turn` come from the *reached* position, not from the played
+    ply's own `move_no`/`color`: after a Black ply the two differ by one.
     """
     for game in games:
-        game.cells = board_utils.fen_to_cells(game.fen)
-        game.move_no = board_utils.fullmove_number(game.fen)
-        game.turn = board_utils.active_color(game.fen)
+        last = board_utils.last_ply_from_pgn(game.pgn)
+        fen = last["fen_after"] if last else game.fen
+
+        game.cells = board_utils.fen_to_cells(fen)
+        game.move_no = board_utils.fullmove_number(fen)
+        game.turn = board_utils.active_color(fen)
         orientation = "white" if game.white_name.lower() == username.lower() else "black"
         game.is_user_turn = game.turn == orientation
     return games

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -58,6 +58,50 @@ class TestPositionsFromPgn:
         assert board.positions_from_pgn(None) == []
 
 
+class TestLastPlyFromPgn:
+    """The home card's position source: one replay, last ply + reached FEN."""
+
+    def test_returns_the_last_played_ply(self):
+        last = board.last_ply_from_pgn(PGN)
+        assert last["move_no"] == 2
+        assert last["color"] == "black"
+        assert last["san"] == "Nc6"
+        assert last["uci"] == "b8c6"
+
+    def test_fen_after_is_the_position_the_ply_reached(self):
+        # Anchors the helper to positions_from_pgn, which the detail page renders
+        # from — the card and the detail page cannot drift apart by a ply.
+        last = board.last_ply_from_pgn(PGN)
+        assert last["fen_after"] == board.positions_from_pgn(PGN)[-1]
+
+    def test_move_number_describes_the_played_move_not_the_next(self):
+        # After 2. Nf3 the *played* ply is White's move 2, but the position is at
+        # move 2 with Black to move; after 2... Nc6 the position moves on to 3.
+        last = board.last_ply_from_pgn('[Event "Test"]\n\n1. e4 e5 2. Nf3 *')
+        assert (last["move_no"], last["color"]) == (2, "white")
+        assert board.fullmove_number(last["fen_after"]) == 2
+        assert board.active_color(last["fen_after"]) == "black"
+
+        assert board.fullmove_number(board.last_ply_from_pgn(PGN)["fen_after"]) == 3
+
+    def test_none_for_missing_or_moveless_pgn(self):
+        assert board.last_ply_from_pgn("") is None
+        assert board.last_ply_from_pgn(None) is None
+        assert board.last_ply_from_pgn('[Event "Test"]\n\n*') is None
+
+    def test_stops_at_the_last_legal_ply(self):
+        last = board.last_ply_from_pgn('[Event "Test"]\n\n1. e4 e5 2. Qq9 *')
+        assert last["san"] == "e5"
+
+    def test_the_returned_dict_is_safe_to_mutate(self):
+        # The replay is memoised on the PGN text; the cache holds an immutable
+        # tuple so a caller mutating its dict can't poison later hits.
+        first = board.last_ply_from_pgn(PGN)
+        first["san"] = "tampered"
+
+        assert board.last_ply_from_pgn(PGN)["san"] == "Nc6"
+
+
 class TestAnnotateMoves:
     def _suggestion(self, fen, best):
         return SimpleNamespace(fen=fen, move_no=None, best_move_san=best)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -83,7 +83,8 @@ class TestHome:
         assert len(games) == 1
         assert games[0].game_id == "944768131"
         assert len(games[0].cells) == 64
-        assert games[0].move_no == 1
+        # The card follows the PGN (4 plies in), not the stale seeded FEN.
+        assert games[0].move_no == 3
 
     def test_does_not_call_chess_com(self, auth_client):
         with patch("chessdotcom_ai_coach.services.chess_client.Client") as mock_client:
@@ -127,6 +128,65 @@ class TestGameList:
         response = auth_client.get("/games")
 
         assert b'href="/game/old1"' in response.content
+
+
+@pytest.mark.django_db
+class TestGameCardPosition:
+    """The home card's mini board follows the PGN, like the detail page does.
+
+    Chess.com's ``fen`` field can lag its own movetext and is empty on some
+    payloads, which used to render the card as an untouched starting position.
+    """
+
+    def test_card_follows_the_pgn_not_a_stale_fen(self, auth_client, user):
+        _make_game(user, fen=FEN_START)  # stale: says nothing has been played
+
+        response = auth_client.get("/games")
+        game = response.context["games"][0]
+
+        expected = board_utils.positions_from_pgn(PGN)[-1]
+        assert game.cells == board_utils.fen_to_cells(expected)
+        assert game.move_no == 3
+        assert game.turn == "white"
+
+    def test_card_falls_back_to_the_stored_fen_without_a_pgn(self, auth_client, user):
+        _make_game(user, pgn="", fen=FEN_LIVE)
+
+        game = auth_client.get("/games").context["games"][0]
+
+        assert game.cells == board_utils.fen_to_cells(FEN_LIVE)
+        assert game.move_no == 3
+        assert game.turn == "white"
+
+    def test_card_without_pgn_or_fen_is_the_untouched_board(self, auth_client, user):
+        _make_game(user, pgn="", fen="")
+
+        game = auth_client.get("/games").context["games"][0]
+
+        # Documented fallback: nothing to draw → the starting position, and the
+        # template hides the move number behind `{% if game.move_no %}`.
+        assert game.cells == board_utils.fen_to_cells(None)
+        assert game.move_no is None
+
+    def test_past_card_shows_the_pgn_position(self, auth_client, user):
+        _make_game(user, is_active=False, fen=FEN_START)
+
+        game = auth_client.get("/games").context["past_games"][0]
+
+        assert game.cells == board_utils.fen_to_cells(
+            board_utils.positions_from_pgn(PGN)[-1]
+        )
+        assert game.move_no == 3
+
+    def test_your_turn_badge_follows_the_pgn(self, auth_client, user):
+        # The user is White. The stale FEN claims White is to move, but the PGN
+        # says White has already played 1. e4 — so it is not their turn.
+        _make_game(user, pgn='[Event "Test"]\n\n1. e4 *', fen=FEN_START)
+
+        response = auth_client.get("/games")
+
+        assert response.context["games"][0].is_user_turn is False
+        assert "Your turn" not in response.content.decode()
 
 
 @pytest.mark.django_db
@@ -806,7 +866,8 @@ class TestGameListStates:
         assert b"No active games" in response.content
 
     def test_your_turn_card(self, auth_client, user):
-        # FEN_START has White (the user) to move → your turn.
+        # The turn is read off the PGN: it ends on a Black ply, so White (the
+        # user) is to move → your turn.
         _make_game(user, fen=FEN_START)
 
         response = auth_client.get("/games")


### PR DESCRIPTION
## Summary
The home page game cards now derive their board position from the PGN movetext rather than the stored FEN field, matching the behavior of the detail page. This fixes cases where Chess.com's FEN field lags behind its own movetext or is missing entirely, which previously rendered cards as untouched starting positions.

## Key Changes
- **Replaced `last_move_from_pgn()` with `last_ply_from_pgn()`**: The new function replays the PGN once and returns the last played ply plus the reached FEN as a dict with keys `{move_no, color, san, uci, fen_after}`. This is more efficient than the previous regex-based parsing and provides the position state needed by the home page.

- **Added `_last_ply_tuple()` helper with LRU caching**: Split out the PGN replay logic into a separate cached function keyed on immutable tuples. This prevents cache poisoning from callers mutating returned dicts, and avoids re-replaying games on the home page's 5-second poll when the PGN hasn't changed.

- **Updated `_decorate_games()` view helper**: Now uses `last_ply_from_pgn()` to derive board position, move number, and turn from the PGN. Falls back to the stored FEN only when no PGN is available (for historical snapshots).

- **Removed regex-based parsing**: Replaced manual tokenization and regex matching with chess.pgn library replay, which is more robust and handles malformed movetext gracefully.

## Notable Implementation Details
- The `fen_after` field represents the position *after* the ply was played, so `move_no`/`color` describe the played move while the position's turn is derived from the reached FEN.
- The cache is keyed on PGN text, which only changes when a move is actually played, minimizing unnecessary replays during polling.
- Comprehensive test coverage added for the new function and its integration with the home page card rendering.

https://claude.ai/code/session_019bAUo2g94EMNwTLLf284nv